### PR TITLE
Added X-Forward-For header setting to haproxy.cfg

### DIFF
--- a/src/filesystem/root/etc/haproxy/haproxy.cfg
+++ b/src/filesystem/root/etc/haproxy/haproxy.cfg
@@ -22,6 +22,7 @@ defaults
 frontend public
         bind *:80
         bind 0.0.0.0:443 ssl crt /etc/ssl/snakeoil.pem
+        option forwardfor except 127.0.0.1
         use_backend webcam if { path_beg /webcam/ }
         default_backend octoprint
 


### PR DESCRIPTION
Adjusted `haproxy.cfg` so that it should add the `X-Forward-For` HTTP client to proxied requests towards OctoPrint, thus allowing autologin by originating network to work properly.
