### PR TITLE
Switch mjpg-streamer-raspicam parameter -d to -fps

### DIFF
--- a/src/filesystem/boot/octopi.txt
+++ b/src/filesystem/boot/octopi.txt
@@ -23,6 +23,6 @@
 # See https://github.com/foosel/OctoPrint/wiki/MJPG-Streamer-configuration
 # for available options
 #
-# Defaults to a delay between pictures of 100 ms == 10fps
+# Defaults to 10fps
 #
-#camera_raspi_options="-d 100"
+#camera_raspi_options="-fps 10"

--- a/src/filesystem/home/.octoprint/config.yaml
+++ b/src/filesystem/home/.octoprint/config.yaml
@@ -1,5 +1,5 @@
 webcam:
-  stream: http://octopi.local:8080/?action=stream
+  stream: /webcam/?action=stream
   snapshot: http://127.0.0.1:8080/?action=snapshot
   ffmpeg: /usr/bin/avconv
 system:

--- a/src/filesystem/home/scripts/webcamDaemon
+++ b/src/filesystem/home/scripts/webcamDaemon
@@ -7,7 +7,7 @@ MJPGSTREAMER_INPUT_RASPICAM="input_raspicam.so"
 # init configuration
 camera="auto"
 camera_usb_options="-r 640x480 -f 10"
-camera_raspi_options="-d 100"
+camera_raspi_options="-fps 10"
 
 if [ -e "/boot/octopi.txt" ]; then
     source "/boot/octopi.txt"
@@ -49,6 +49,8 @@ while true; do
         startUsb
     elif [ "`vcgencmd get_camera`" = "supported=1 detected=1" ] && { [ "$camera" = "auto" ] || [ "$camera" = "raspi" ] ; }; then
         startRaspi
+    else
+        echo "No camera detected, trying again in two minutes"
     fi
 
     sleep 120


### PR DESCRIPTION
Also added additional webcamDaemon output to give a hint whether a webcam
was detected or not and switched stream URL to also work in case no name resolution of Pi via bonjour/avahi doesn't work for the user and instead an IP or alternative hostname is used.
