### PR TITLE
Do not copy boot and root into home directory

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -9,18 +9,22 @@ fixLd(){
 }
 
 unpackHome(){
-  chown -hR pi /filesystem/home
-  chgrp -hR pi /filesystem/home
+  shopt -s dotglob
   cp -av /filesystem/home/* /home/pi
-  cp -av /filesystem/home/.* /home/pi
+  shopt -u dotglob
+  chown -hR pi:pi /home/pi
 }
 
 unpackRoot(){
+  shopt -s dotglob
   cp -av /filesystem/root/* /
+  shopt -u dotglob
 }
 
 unpackBoot(){
+  shopt -s dotglob
   cp -av /filesystem/boot/* /boot
+  shopt -u dotglob
 }
 
 fixLd


### PR DESCRIPTION
The former method of copying the contents of filesystem/home was a bit too
recursive and also caught filesystem/boot and filesystem/root due to the
cp -av .\* also matching ..

Using dotglob instead fixes this. While at it also turned the chown
and chgrp into one single command.

See also final comments in #42 
