### PR TITLE
Fixed typo causing #60 and caused by #50

### DIFF
--- a/src/filesystem/root/etc/haproxy/haproxy.cfg
+++ b/src/filesystem/root/etc/haproxy/haproxy.cfg
@@ -27,7 +27,7 @@ frontend public
         default_backend octoprint
 
 backend octoprint
-        reqrep ^([^\ :]*)\ /(.*) \^\ /\2
+        reqrep ^([^\ :]*)\ /(.*) \1\ /\2
         reqadd X-Scheme:\ https if { ssl_fc }
         option forwardfor
         server octoprint1 127.0.0.1:5000


### PR DESCRIPTION
I have no idea  how that crept into a *copy and paste* but my guess is that that's the reason for #60 (at least it behaves exactly the same when I change my haproxy config to that). Sorry for that, again, I have no idea how that happened, I copy pasted the config.