### PR TITLE
New library needed for compiling mjpg_streamer

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -69,7 +69,7 @@ pushd /home/pi
   sudo usermod -a -G dialout pi
       
   #mjpg-streamer
-  sudo apt-get -y --force-yes install subversion libjpeg8-dev imagemagick libav-tools cmake
+  sudo apt-get -y --force-yes install subversion libjpeg8-dev imagemagick libav-tools cmake libv4l-dev
   gitclone https://github.com/jacksonliam/mjpg-streamer.git
   pushd mjpg-streamer
     mv mjpg-streamer-experimental/* .


### PR DESCRIPTION
At least I got compile errors without that. That plus
https://github.com/jacksonliam/mjpg-streamer/pull/3 (after
merge!) should fix the mjpg_streamer issues with kernel 3.18