### PR TITLE
Support for OctoPi variants and flavors (like mr beam's fork)

### DIFF
--- a/src/build
+++ b/src/build
@@ -1,4 +1,32 @@
 #!/usr/bin/env bash
+
+source ./util.sh
+
 OCTOPI_PATH=$(dirname $(realpath -s $0))
+
+BUILD_VARIANT=default
+BUILD_FLAVOR=default
+
+if [ "$#" -eq 1 ]; then
+  BUILD_VARIANT=$1
+elif [ "$#" -eq 2 ]; then
+  BUILD_VARIANT=$1
+  BUILD_FLAVOR=$2
+fi
+
+if [ $BUILD_VARIANT != 'default' ]; then
+  export VARIANT_BASE="$OCTOPI_PATH/variants/$BUILD_VARIANT"
+  [ -d $VARIANT_BASE ] || die "Could not find Variant $BUILD_VARIANT"
+  if [ $BUILD_FLAVOR == '' ] || [ $BUILD_FLAVOR == 'default' ]; then
+    FLAVOR_CONFIG=$VARIANT_BASE/config
+  else
+    FLAVOR_CONFIG=$VARIANT_BASE/config.$BUILD_FLAVOR
+  fi
+  source $FLAVOR_CONFIG || die "Could not find config file $FLAVOR_CONFIG"
+
+  echo "Building VARIANT $BUILD_VARIANT, FLAVOR $BUILD_FLAVOR"
+fi
+
+
 source $OCTOPI_PATH/config
 source $OCTOPI_PATH/octopi

--- a/src/build
+++ b/src/build
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-source ./util.sh
+source ./common.sh
 
 OCTOPI_PATH=$(dirname $(realpath -s $0))
 
 BUILD_VARIANT=default
 BUILD_FLAVOR=default
 
-if [ "$#" -eq 1 ]; then
+if [ "$#" -gt 0 ]; then
   BUILD_VARIANT=$1
-elif [ "$#" -eq 2 ]; then
-  BUILD_VARIANT=$1
+fi
+if [ "$#" -gt 1 ]; then
   BUILD_FLAVOR=$2
 fi
 
@@ -23,10 +23,9 @@ if [ $BUILD_VARIANT != 'default' ]; then
     FLAVOR_CONFIG=$VARIANT_BASE/config.$BUILD_FLAVOR
   fi
   source $FLAVOR_CONFIG || die "Could not find config file $FLAVOR_CONFIG"
-
-  echo "Building VARIANT $BUILD_VARIANT, FLAVOR $BUILD_FLAVOR"
 fi
 
+echo -e "--> Building VARIANT $BUILD_VARIANT, FLAVOR $BUILD_FLAVOR"
 
 source $OCTOPI_PATH/config
 source $OCTOPI_PATH/octopi

--- a/src/chroot_script
+++ b/src/chroot_script
@@ -4,38 +4,8 @@ set -x
 # Helper script that runs in a Raspbian chroot to create the OctoPI distro
 # Written by Guy Sheffer <guysoft at gmail dot com>
 # GPL V3
-fixLd(){
-  sed -i 's@/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@\#/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@' /etc/ld.so.preload
-}
 
-gitclone(){
-if [ $GIT_REPO_OVERRIDE != "" ] ; then
-    REPO=$GIT_REPO_OVERRIDE`echo $1 | awk -F '/' '{print $(NF)}'`
-    sudo -u pi git clone $REPO
-    sudo -u pi git remote set-url $1
-else
-    sudo -u pi git clone $1
-fi
-}
-
-unpackHome(){
-  shopt -s dotglob
-  cp -av /filesystem/home/* /home/pi
-  shopt -u dotglob
-  chown -hR pi:pi /home/pi
-}
-
-unpackRoot(){
-  shopt -s dotglob
-  cp -av /filesystem/root/* /
-  shopt -u dotglob
-}
-
-unpackBoot(){
-  shopt -s dotglob
-  cp -av /filesystem/boot/* /boot
-  shopt -u dotglob
-}
+source /util.sh
 
 fixLd
 unpackHome
@@ -52,11 +22,14 @@ pushd /home/pi
   #build virtualenv
   sudo -u pi virtualenv --system-site-packages oprint
   
-  #OctoPrint
-  gitclone https://github.com/foosel/OctoPrint.git
-  pushd OctoPrint
-    sudo -u pi /home/pi/oprint/bin/python setup.py install
-  popd
+  if [ -n $OVERRIDE_OCTOPRINT ]
+  then
+    #OctoPrint
+    gitclone https://github.com/foosel/OctoPrint.git
+    pushd OctoPrint
+      sudo -u pi /home/pi/oprint/bin/python setup.py install
+    popd
+  fi
 
   #OctoPiPanel
   gitclone https://github.com/jonaslorander/OctoPiPanel.git

--- a/src/chroot_script
+++ b/src/chroot_script
@@ -7,7 +7,6 @@ set -x
 
 source /util.sh
 
-fixLd
 unpackHome
 unpackBoot
 apt-get update
@@ -122,7 +121,4 @@ unpackRoot
 sudo update-rc.d octoprint defaults 99
 
 #cleanup
-fixLd
 sudo apt-get clean
-
-sed -i 's@\#/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@' /etc/ld.so.preload

--- a/src/chroot_script
+++ b/src/chroot_script
@@ -5,7 +5,7 @@ set -x
 # Written by Guy Sheffer <guysoft at gmail dot com>
 # GPL V3
 
-source /util.sh
+source /common.sh
 
 unpackHome
 unpackBoot

--- a/src/chroot_script
+++ b/src/chroot_script
@@ -106,8 +106,8 @@ echo "pi ALL=NOPASSWD: /sbin/service" > /etc/sudoers.d/octoprint-service
 
 #reach printer by name
 sudo apt-get -y --force-yes install avahi-daemon
-echo octopi > /etc/hostname
-sed -i 's@raspberrypi@octopi@' /etc/hosts
+echo "$OVERRIDE_HOSTNAME" > /etc/hostname
+sed -i -e "s@raspberrypi@$OVERRIDE_HOSTNAME@g" /etc/hosts
 
 # enable raspicam
 echo "# enable raspicam" >> /boot/config.txt

--- a/src/common.sh
+++ b/src/common.sh
@@ -25,20 +25,20 @@ fi
 
 function unpackHome(){
   shopt -s dotglob
-  cp -av /filesystem/home/* /home/pi
+  cp -v -r --preserve=mode,timestamps /filesystem/home/* /home/pi
   shopt -u dotglob
   chown -hR pi:pi /home/pi
 }
 
 function unpackRoot(){
   shopt -s dotglob
-  cp -av /filesystem/root/* /
+  cp -v -r --preserve=mode,timestamps /filesystem/root/* /
   shopt -u dotglob
 }
 
 function unpackBoot(){
   shopt -s dotglob
-  cp -av /filesystem/boot/* /boot
+  cp -v -r --preserve=mode,timestamps /filesystem/boot/* /boot
   shopt -u dotglob
 }
 

--- a/src/common.sh
+++ b/src/common.sh
@@ -45,5 +45,5 @@ function unpackBoot(){
 function install_fail_on_error_trap() {
   set -e
   trap 'previous_command=$this_command; this_command=$BASH_COMMAND' DEBUG
-  trap 'echo -e "\nexit $? due to $previous_command \nBUILD FAILED!"' EXIT
+  trap 'if [ $? -ne 0 ]; then echo -e "\nexit $? due to $previous_command \nBUILD FAILED!"; fi' EXIT
 }

--- a/src/config
+++ b/src/config
@@ -12,6 +12,7 @@ fi
 [ -n "$OCTOPI_WORKSPACE" ] || OCTOPI_WORKSPACE=$SCRIPT_PATH/workspace
 [ -n "$CHROOT_SCRIPT_PATH" ] || CHROOT_SCRIPT_PATH=$SCRIPT_PATH/chroot_script
 [ -n "$MOUNT_PATH" ] || MOUNT_PATH=$OCTOPI_WORKSPACE/mount
+[ -n "$OVERRIDE_HOSTNAME" ] || OVERRIDE_HOSTNAME=octopi
 
 echo "================================================================"
 echo "Using the following config:"
@@ -21,4 +22,5 @@ echo "ZIP_IMG = $ZIP_IMG"
 echo "OCTOPI_WORKSPACE = $OCTOPI_WORKSPACE"
 echo "CHROOT_SCRIPT_PATH = $CHROOT_SCRIPT_PATH"
 echo "MOUNT_PATH = $MOUNT_PATH"
+echo "OVERRIDE_HOSTNAME = $OVERRIDE_HOSTNAME"
 echo "================================================================"

--- a/src/octopi
+++ b/src/octopi
@@ -39,6 +39,8 @@ pushd $OCTOPI_WORKSPACE
   pushd $MOUNT_PATH
 
     #make QEMU boot (remember to return)
+    source util.sh
+    fixLd
     #sed -i 's@include /etc/ld.so.conf.d/\*.conf@\#include /etc/ld.so.conf.d/\*.conf@' etc/ld.so.conf
 
     # execute the base chroot script
@@ -48,6 +50,8 @@ pushd $OCTOPI_WORKSPACE
     if [ -n $VARIANT_BASE ]; then
       execute_chroot_script $VARIANT_BASE $VARIANT_BASE/chroot_script
     fi
+    
+    restoreLd
   popd
   
   # unmount first boot, then root partition

--- a/src/octopi
+++ b/src/octopi
@@ -4,6 +4,9 @@
 # Written by Guy Sheffer <guysoft at gmail dot com>
 # GPL V3
 
+source $SCRIPT_PATH/common.sh
+install_fail_on_error_trap
+
 function execute_chroot_script() {
   #move OctoPi filesystem files
   cp -av $1/filesystem .
@@ -13,8 +16,8 @@ function execute_chroot_script() {
   
   cp $2 chroot_script
   chmod 755 chroot_script
-  cp $SCRIPT_PATH/util.sh util.sh
-  chmod 755 util.sh
+  cp $SCRIPT_PATH/common.sh common.sh
+  chmod 755 common.sh
   
   chroot . usr/bin/qemu-arm-static /bin/bash /chroot_script
   
@@ -27,7 +30,9 @@ mkdir -p $OCTOPI_WORKSPACE
 mkdir -p $MOUNT_PATH
 
 pushd $OCTOPI_WORKSPACE
-  rm *.img
+  if [ -e *.img ]; then  
+    rm *.img
+  fi
   unzip $ZIP_IMG
   IMG_PATH=`ls | grep .img`
 
@@ -39,12 +44,11 @@ pushd $OCTOPI_WORKSPACE
   pushd $MOUNT_PATH
 
     #make QEMU boot (remember to return)
-    source util.sh
     fixLd
     #sed -i 's@include /etc/ld.so.conf.d/\*.conf@\#include /etc/ld.so.conf.d/\*.conf@' etc/ld.so.conf
 
     # execute the base chroot script
-    #execute_chroot_script $SCRIPT_PATH $CHROOT_SCRIPT_PATH
+    execute_chroot_script $SCRIPT_PATH $CHROOT_SCRIPT_PATH
     
     # if building a variant, execute its chroot script
     if [ -n $VARIANT_BASE ]; then

--- a/src/octopi
+++ b/src/octopi
@@ -3,6 +3,26 @@
 # This script takes a Raspbian image and adds to it octoprint and verions addons
 # Written by Guy Sheffer <guysoft at gmail dot com>
 # GPL V3
+
+function execute_chroot_script() {
+  #move OctoPi filesystem files
+  cp -av $1/filesystem .
+
+  #black magic of qemu-arm-static
+  cp `which qemu-arm-static` usr/bin
+  
+  cp $2 chroot_script
+  chmod 755 chroot_script
+  cp $SCRIPT_PATH/util.sh util.sh
+  chmod 755 util.sh
+  
+  chroot . usr/bin/qemu-arm-static /bin/bash /chroot_script
+  
+  #cleanup
+  rm chroot_script
+  rm -rfv filesystem
+}
+
 mkdir -p $OCTOPI_WORKSPACE
 mkdir -p $MOUNT_PATH
 
@@ -21,19 +41,13 @@ pushd $OCTOPI_WORKSPACE
     #make QEMU boot (remember to return)
     #sed -i 's@include /etc/ld.so.conf.d/\*.conf@\#include /etc/ld.so.conf.d/\*.conf@' etc/ld.so.conf
 
-    #move OctoPi filesystem files
-    cp -av $SCRIPT_PATH/filesystem . 
-
-    #black magic of qemu-arm-static
-    cp `which qemu-arm-static` usr/bin
-    cp $CHROOT_SCRIPT_PATH chroot_script
-    chmod 755 chroot_script
+    # execute the base chroot script
+    #execute_chroot_script $SCRIPT_PATH $CHROOT_SCRIPT_PATH
     
-    chroot . usr/bin/qemu-arm-static /bin/bash /chroot_script
-    
-    #cleanup
-    rm chroot_script
-    rm -rfv filesystem
+    # if building a variant, execute its chroot script
+    if [ -n $VARIANT_BASE ]; then
+      execute_chroot_script $VARIANT_BASE $VARIANT_BASE/chroot_script
+    fi
   popd
   
   # unmount first boot, then root partition

--- a/src/octopi
+++ b/src/octopi
@@ -9,7 +9,7 @@ install_fail_on_error_trap
 
 function execute_chroot_script() {
   #move OctoPi filesystem files
-  cp -av $1/filesystem .
+  cp -vr --preserve=mode,timestamps $1/filesystem .
 
   #black magic of qemu-arm-static
   cp `which qemu-arm-static` usr/bin

--- a/src/util.sh
+++ b/src/util.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+function die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+function fixLd(){
+  sed -i 's@/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@\#/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@' /etc/ld.so.preload
+}
+
+function gitclone(){
+if [ $GIT_REPO_OVERRIDE != "" ] ; then
+    REPO=$GIT_REPO_OVERRIDE`echo $1 | awk -F '/' '{print $(NF)}'`
+    sudo -u pi git clone $REPO
+    sudo -u pi git remote set-url $1
+else
+    sudo -u pi git clone $1
+fi
+}
+
+function unpackHome(){
+  shopt -s dotglob
+  cp -av /filesystem/home/* /home/pi
+  shopt -u dotglob
+  chown -hR pi:pi /home/pi
+}
+
+function unpackRoot(){
+  shopt -s dotglob
+  cp -av /filesystem/root/* /
+  shopt -u dotglob
+}
+
+function unpackBoot(){
+  shopt -s dotglob
+  cp -av /filesystem/boot/* /boot
+  shopt -u dotglob
+}
+
+function install_fail_on_error_trap() {
+  set -e
+  trap 'previous_command=$this_command; this_command=$BASH_COMMAND' DEBUG
+  trap 'echo -e "\nexit $? due to $previous_command \nBUILD FAILED!"' EXIT
+}

--- a/src/util.sh
+++ b/src/util.sh
@@ -6,7 +6,11 @@ function die () {
 }
 
 function fixLd(){
-  sed -i 's@/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@\#/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@' /etc/ld.so.preload
+  sed -i 's@/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@\#/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@' etc/ld.so.preload
+}
+
+function restoreLd(){
+  sed -i 's@\#/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@/usr/lib/arm-linux-gnueabihf/libcofi_rpi.so@' etc/ld.so.preload
 }
 
 function gitclone(){

--- a/src/variants/example/chroot_script
+++ b/src/variants/example/chroot_script
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
-source /util.sh
+source /common.sh
 
 # exit script on any error
 install_fail_on_error_trap
 
 #change the hostname 
-sudo sed -i 's@octopi@example@' /etc/hosts
+sed -i 's@octopi@example@' /etc/hosts
 
 # install dhclient.conf and possibly other files
 unpackRoot
 
 #cleanup
-sudo apt-get clean
+apt-get clean

--- a/src/variants/example/chroot_script
+++ b/src/variants/example/chroot_script
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source /util.sh
+
+# exit script on any error
+install_fail_on_error_trap
+
+#change the hostname 
+sudo sed -i 's@octopi@example@' /etc/hosts
+
+# install dhclient.conf and possibly other files
+unpackRoot
+
+#cleanup
+fixLd
+sudo apt-get clean

--- a/src/variants/example/chroot_script
+++ b/src/variants/example/chroot_script
@@ -12,5 +12,4 @@ sudo sed -i 's@octopi@example@' /etc/hosts
 unpackRoot
 
 #cleanup
-fixLd
 sudo apt-get clean

--- a/src/variants/example/config
+++ b/src/variants/example/config
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# make sure to export all the variables to make them available to the chroot scripts as well
+
+# customize the hostname 
+export OVERRIDE_HOSTNAME=blueberrypi
+
+# skip octoprint installation in main build script 
 export OVERRIDE_OCTOPRINT=yes

--- a/src/variants/example/config
+++ b/src/variants/example/config
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+export OVERRIDE_OCTOPRINT=yes

--- a/src/variants/example/config.nightly
+++ b/src/variants/example/config.nightly
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+export OVERRIDE_HOSTNAME=blueberrypi
 export OVERRIDE_OCTOPRINT=no

--- a/src/variants/example/config.nightly
+++ b/src/variants/example/config.nightly
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+export OVERRIDE_OCTOPRINT=no


### PR DESCRIPTION
added support for variants that modify the octopi build. introduced a folder 'variants' in which each variant occupies a subfolder. these subfolders can have config files, chroot_scripts and filesystem overlays just like the original octopi build script, which get applied after the base octopi image is built. flavors just are different config files at the moment. 

see src/variants/example for and example.