### PR TITLE
Fix for guysofl/OctoPi#84: Uninstall python-serial

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -11,7 +11,7 @@ unpackHome
 unpackBoot
 apt-get update
 
-apt-get remove -y --purge scratch squeak-plugins-scratch squeak-vm wolfram-engine python-minecraftpi minecraft-pi sonic-pi oracle-java8-jdk
+apt-get remove -y --purge scratch squeak-plugins-scratch squeak-vm wolfram-engine python-minecraftpi minecraft-pi sonic-pi oracle-java8-jdk python-serial
 
 #apt-get octoprint virtualenv
 apt-get -y --force-yes install python-virtualenv python-dev git python-numpy screen libts-bin


### PR DESCRIPTION
Due to the site-package being active in the OctoPrint
virtualenv, sometimes the site wide installed version
of pyserial got used, leading to errors when trying
to connect to 250k baud firmwares.

Just removing the preinstalled variant (which contrary
to some reports seems to NOT include the patch for
250k support) solves that.