### PR TITLE
Fix for #95: Check for zero sized ssl files

### DIFF
--- a/src/filesystem/home/scripts/genCert
+++ b/src/filesystem/home/scripts/genCert
@@ -1,6 +1,10 @@
 #!/bin/bash
-if [ ! -f /etc/ssl/private/ssl-cert-snakeoil.key ]; then
+keyfile=/etc/ssl/private/ssl-cert-snakeoil.key
+pemfile=/etc/ssl/certs/ssl-cert-snakeoil.pem
+certfile=/etc/ssl/snakeoil.pem
+
+if [ ! -f $keyfile ] || [ ! -s $keyfile ] || [ ! -f $pemfile ] || [ ! -s $pemfile ] || [ ! -f $certfile ] || [ ! -s $certfile ]; then
     echo "Generating SSL certificate"
     sudo make-ssl-cert generate-default-snakeoil --force-overwrite 
-    sudo cat /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/certs/ssl-cert-snakeoil.pem > /etc/ssl/snakeoil.pem
+    sudo cat $keyfile $pemfile > $certfile
 fi


### PR DESCRIPTION
While this doesn't solve the problem of these files being generated
at 0 bytes size in the first place, it at least should make
OctoPi reattempt to generate the certificate and thus fix the
issue described in #95 (possibly after a couple of reboots).