### PR TITLE
Bind OctoPrint only to 127.0.0.1

### DIFF
--- a/src/filesystem/root/etc/default/octoprint
+++ b/src/filesystem/root/etc/default/octoprint
@@ -3,6 +3,9 @@
 # The init.d script will only run if this variable non-empty.
 OCTOPRINT_USER=pi
 
+# To what host to bind daemon, default is 127.0.0.1
+HOST=127.0.0.1
+
 # On what port to run daemon, default is 5000
 PORT=5000
 
@@ -10,7 +13,7 @@ PORT=5000
 DAEMON=/home/pi/oprint/bin/octoprint
 
 # What arguments to pass to octoprint, usually no need to touch this
-DAEMON_ARGS="--port=$PORT"
+DAEMON_ARGS="--host=$HOST --port=$PORT"
 
 # Umask of files octoprint generates, Change this to 000 if running octoprint as its own, separate user
 UMASK=022


### PR DESCRIPTION
This will prevent connections to http://<ip>:5000 from working and
hence hopefully reduce the amount of support requests by users who
connect with port 5000 for whatever reason and then don't understand
why their webcams won't work.

Should probably only be merged once the fix for #95 has been merged,
since this effectively makes OctoPi only serve OctoPrint if haproxy
is actually running.