### PR TITLE
Added configuration for Software Update plugin

### DIFF
--- a/src/filesystem/home/.octoprint/config.yaml
+++ b/src/filesystem/home/.octoprint/config.yaml
@@ -2,6 +2,12 @@ webcam:
   stream: /webcam/?action=stream
   snapshot: http://127.0.0.1:8080/?action=snapshot
   ffmpeg: /usr/bin/avconv
+plugins:
+  softwareupdate:
+    checks:
+      update_folder: /home/pi/OctoPrint
+    octoprint_restart_command: sudo service octoprint restart
+    environment_restart_command: sudo shutdown -r now
 system:
   actions:
   - name: Shutdown


### PR DESCRIPTION
The plugin now is bundled with the current devel of OctoPrint,
this makes it work on OctoPi (although since this configuration
limits it to updating to releases only nothing can be seen
yet).