### PR TITLE
Moved mount/umount commands to functions

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -50,3 +50,20 @@ function install_fail_on_error_trap() {
   trap 'previous_command=$this_command; this_command=$BASH_COMMAND' DEBUG
   trap 'if [ $? -ne 0 ]; then echo -e "\nexit $? due to $previous_command \nBUILD FAILED!"; fi' EXIT
 }
+
+function mount_image() {
+  image_path=$1
+  mount_path=$2
+
+  # mount root and boot partition
+  sudo mount -o loop,offset=$((512*122880)) $image_path $mount_path
+  sudo mount -o loop,offset=$((512*8192)) $image_path $mount_path/boot
+}
+
+function unmount_image() {
+  mount_path=$1
+
+  # unmount first boot, then root partition
+  sudo umount $mount_path/boot
+  sudo umount $mount_path
+}

--- a/src/octopi
+++ b/src/octopi
@@ -37,8 +37,7 @@ pushd $OCTOPI_WORKSPACE
   IMG_PATH=`ls | grep .img`
 
   # mount root and boot partition
-  sudo mount -o loop,offset=$((512*122880)) $IMG_PATH $MOUNT_PATH
-  sudo mount -o loop,offset=$((512*8192)) $IMG_PATH $MOUNT_PATH/boot
+  mount_image $IMG_PATH $MOUNT_PATH
 
   #Edit pi filesystem
   pushd $MOUNT_PATH
@@ -63,8 +62,7 @@ pushd $OCTOPI_WORKSPACE
   popd
   
   # unmount first boot, then root partition
-  sudo umount $MOUNT_PATH/boot
-  sudo umount $MOUNT_PATH
+  unmount_image $MOUNT_PATH
   chmod 777 $IMG_PATH
 popd
 


### PR DESCRIPTION
Helps a lot in checking out the image after building since 

    source common.sh
    mount_image $image_path $mount_path

is way faster typed down than 2 x `mount -o loop,offset=....`
if you just want to quickly mount it to look if some file looks
correct.