### PR TITLE
Added wrapper script for git for sudo

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -9,6 +9,7 @@ set -e
 source /common.sh
 
 unpack /filesystem/home/pi /home/pi pi
+unpack /filesystem/home/root /root root
 unpack /filesystem/boot /boot
 apt-get update
 
@@ -138,6 +139,11 @@ echo "pi ALL=NOPASSWD: /sbin/service" > /etc/sudoers.d/octoprint-service
 sudo apt-get -y --force-yes install avahi-daemon
 echo "$OCTOPI_OVERRIDE_HOSTNAME" > /etc/hostname
 sed -i -e "s@raspberrypi@$OCTOPI_OVERRIDE_HOSTNAME@g" /etc/hosts
+
+#make sure users don't run git with sudo, thus breaking permissions, by adding /root/bin to the
+#default sudo path and placing a git wrapper script there that checks if it's run as root
+sed -i "s@secure_path=\"@secure_path=\"/root/bin:@g" /etc/sudoers
+chmod +x /root/bin/git
 
 # enable raspicam
 echo "# enable raspicam" >> /boot/config.txt

--- a/src/filesystem/home/root/bin/git
+++ b/src/filesystem/home/root/bin/git
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$(id -u)" == "0" ]
+then
+  echo "Please run git without sudo, your regular user account is enough :)" 2>&1
+  exit 1
+fi
+
+/usr/bin/git "$@"


### PR DESCRIPTION
This will be found first when executing sudo git and checks whether
it is running with super user privileges and if so refuses to do
that and instead just prints a friendly message to please run git
without sudo.

Reason: Apparently users tend to do a "sudo git pull" when updating
OctoPrint, effectively screwing up their permissions in the process
and then running into problems later on. This should hopefully act
as an educational measure to stop this from happening.