### PR TITLE
Enabled proper discovery of OctoPrint

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -15,7 +15,7 @@ apt-get update
 apt-get remove -y --purge scratch squeak-plugins-scratch squeak-vm wolfram-engine python-minecraftpi minecraft-pi sonic-pi oracle-java8-jdk
 
 #apt-get octoprint virtualenv
-apt-get -y --force-yes install python2.7 python-virtualenv python-dev git screen libts-bin subversion cmake checkinstall
+apt-get -y --force-yes install python2.7 python-virtualenv python-dev git screen libts-bin subversion cmake checkinstall avahi-daemon libavahi-compat-libdnssd1
 
 pushd /home/pi
 
@@ -35,6 +35,9 @@ pushd /home/pi
       sudo -u pi /home/pi/oprint/bin/python setup.py install
     popd
     
+    #pybonjour (for mdns discovery)
+    sudo -u pi /home/pi/oprint/bin/pip install pybonjour
+
     #OctoPrint
     gitclone OCTOPI_OCTOPRINT_REPO OctoPrint
     pushd OctoPrint
@@ -135,7 +138,6 @@ echo "pi ALL=NOPASSWD: /sbin/shutdown" > /etc/sudoers.d/octoprint-shutdown
 echo "pi ALL=NOPASSWD: /sbin/service" > /etc/sudoers.d/octoprint-service
 
 #reach printer by name
-sudo apt-get -y --force-yes install avahi-daemon
 echo "$OCTOPI_OVERRIDE_HOSTNAME" > /etc/hostname
 sed -i -e "s@raspberrypi@$OCTOPI_OVERRIDE_HOSTNAME@g" /etc/hosts
 

--- a/src/filesystem/home/pi/.octoprint/config.yaml
+++ b/src/filesystem/home/pi/.octoprint/config.yaml
@@ -5,6 +5,8 @@ webcam:
 plugins:
   cura:
     cura_engine: /usr/local/bin/cura_engine
+  discovery:
+    publicPort: 80
   softwareupdate:
     checks:
       octoprint:


### PR DESCRIPTION
Install pybonjour & set external port in config.yaml to publish `_octoprint._tcp` and `_http._tcp` mdns services on. Pybonjour also needs `avahi-daemon` and `libavahi-compat-libdnssd1`, so moved the former up from further down in the script and added the latter.

When this patch is applied, OctoPrint should announce itself on the local network as both HTTP and OctoPrint service (and also allow plugins to utilize the mdns helper functionality included in OctoPrint's bundled discovery plugin to discover mdns services on the local network such as Growl servers).