### PR TITLE
Fixes webcamDaemon for Logitech C170

### DIFF
--- a/src/filesystem/boot/octopi.txt
+++ b/src/filesystem/boot/octopi.txt
@@ -18,6 +18,28 @@
 #
 #camera_usb_options="-r 640x480 -f 10"
 
+### Additional webcam devices known to cause problems with -f
+#
+# Apparently there a some devices out there that with the current 
+# mjpg_streamer release do not support the -f parameter (for specifying 
+# the capturing framerate) and will just refuse to output an image if it 
+# is supplied.
+#
+# The webcam daemon will detect those devices by their USB Vendor and Product
+# ID and remove the -f parameter from the options provided to mjpg_streamer.
+#
+# By default, this is done for the following devices:
+#   Logitech C170 (046d:082b)
+#
+# Using the following option it is possible to add additional devices. If
+# your webcam happens to show above symptoms, try determining your cam's
+# vendor and product id via lsusb, activating the line below by removing # and 
+# adding it as shown examplatory.
+#
+# If this fixes your problem, please report it back so we can include the device
+# out of the box.
+#additional_brokenfps_usb_devices=("046d:082b" "aabb:ccdd")
+
 ### additional options to supply to MJPG Streamer for the RasPi Cam
 #
 # See https://github.com/foosel/OctoPrint/wiki/MJPG-Streamer-configuration

--- a/src/filesystem/home/pi/scripts/webcamDaemon
+++ b/src/filesystem/home/pi/scripts/webcamDaemon
@@ -8,10 +8,13 @@ MJPGSTREAMER_INPUT_RASPICAM="input_raspicam.so"
 camera="auto"
 camera_usb_options="-r 640x480 -f 10"
 camera_raspi_options="-fps 10"
+additional_brokenfps_usb_devices=()
 
 if [ -e "/boot/octopi.txt" ]; then
     source "/boot/octopi.txt"
 fi
+
+brokenfps_usb_devices=("046d:082b" "${additional_brokenfps_usb_devices[@]}")
 
 # runs MJPG Streamer, using the provided input plugin + configuration
 function runMjpgStreamer {
@@ -30,8 +33,39 @@ function startRaspi {
 
 # starts up the USB webcam
 function startUsb {
+    options="$camera_usb_options"
+    device="video0"
+    
+    extracted_device=`echo $options | sed 's@.*-d /dev/\(video[0-9]+\).*@\1@'`
+    if [ "$extracted_device" != "$options" ]
+    then
+        # the camera options refer to another device, use that for determining product
+        device=$extracted_device
+    fi
+
+    uevent_file="/sys/class/video4linux/$device/device/uevent"
+    if [ -e $uevent_file ]; then
+        # let's see what kind of webcam we have here, fetch vid and pid...
+        product=`cat $uevent_file | grep PRODUCT | cut -d"=" -f2`
+        vid=`echo $product | cut -d"/" -f1`
+        pid=`echo $product | cut -d"/" -f2`
+        vidpid=`printf "%04x:%04x" "0x$vid" "0x$pid"` 
+
+        # ... then look if it is in our list of known broken-fps-devices and if so remove
+        # the -f parameter from the options (if it's in there, else that's just a no-op)
+        for identifier in ${brokenfps_usb_devices[@]};
+        do
+            if [ "$vidpid" = "$identifier" ]; then
+                echo
+                echo "Camera model $vidpid is known to not work with -f parameter, stripping it out"
+                echo
+                options=`echo $options | sed -e "s/\(\s\+\|^\)-f\s\+[0-9]\+//g"`
+            fi
+        done
+    fi
+
     logger -s "Starting USB webcam"
-    runMjpgStreamer "$MJPGSTREAMER_INPUT_USB $camera_usb_options"
+    runMjpgStreamer "$MJPGSTREAMER_INPUT_USB $options"
 }
 
 # we need this to prevent the later calls to vcgencmd from blocking


### PR DESCRIPTION
For whatever reason using the -f parameter with that specific camera
model causes it to just not output any image. mjpgstreamer will start
up just fine and not log an error or anything, the camera will appear
to start up too, but when connecting to the webcam stream nothing will
be displayed at all. Just removing the -f parameter in this case fixes
it completely.

This patch adds a new check to the webcamDaemon when starting up a
USB webcam which checks the webcams USB vid and pid against a list
of webcams known not to work with -f (right now that's just the C170,
but more can be added easily by the user through the new
additional_brokenfps_usb_devices option in /boot/octopi.txt) and if
a match is found strips the -f parameter from the camera options.

This is the only way I found I could make a C170 work. It would
probably be cleaner to try to debug what's going wrong in mjpgstreamer
there, but since that might as well be a problem with the chipset
driver of the C170, this is a workaround that should at least
yield a picture at a default frame rate.