### PR TITLE
Allows network configuration without booting

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -152,6 +152,11 @@ echo "# enable raspicam" >> /boot/config.txt
 echo "start_x=1" >> /boot/config.txt
 echo "gpu_mem=128" >> /boot/config.txt
 
+# allow network configuration via /boot/octopi-network.txt
+sed -i "s@wpa-conf@# wpa-conf@g" /etc/network/interfaces
+sed -i "s@iface wlan@# iface wlan@g" /etc/network/interfaces
+echo "source /boot/octopi-network.txt" >> /etc/network/interfaces
+
 #unpack root in the end, so etc file are not overwritten, might need to add two roots int he future
 unpack /filesystem/root /
 

--- a/src/filesystem/boot/octopi-network.txt
+++ b/src/filesystem/boot/octopi-network.txt
@@ -1,0 +1,53 @@
+# You can use this file to manually set up your network configuration.
+#
+# This file is included into /etc/network/interfaces, so anything that
+# works by editing that file is also possible here.
+
+### WIFI CONFIGURATION ######################################################
+# The three segments below should cover you in most cases if you run
+# a wifi network that uses either WPA/WPA2 or WEP encryption.
+#
+# Just uncomment the lines prefixed with a single # of the configuration
+# that matches your wifi setup and fill in SSID and passphrase.
+
+## WPA/WPA2 secured
+#iface wlan0 inet manual
+#    wpa-ssid "put SSID here"
+#    wpa-psk "put password here"
+
+## WEP secured
+#iface wlan0 inet manual
+#    wireless-essid "put SSID here"
+#    wireless-key "put password here"
+
+## Open/unsecured
+#iface wlan0 inet manual
+#    wireless-essid "put SSID here"
+#    wireless-mode managed
+
+### WIRED CONFIGURATION #####################################################
+# The following segment allows you to configure your wired connection
+# with a static IP.
+#
+# Just uncomment the lines prefixed with a single #. Then connect 
+# a cable to the Pi and another system, e.g. a Laptop, and set that
+# other system's network configuration to:
+#
+#   address:   192.168.250.10
+#   netmask:   255.255.255.0
+#   broadcast: 192.168.250.255
+#
+# You can then reach the Pi from the system's browser by going to
+#
+#   http://192.168.250.1
+#
+# or
+#
+#   http://octopi.local
+
+#auto eth0:1
+#iface eth0:1 inet static
+#  address 192.168.250.1
+#  netmask 255.255.255.0
+#  broadcast 192.168.250.255
+


### PR DESCRIPTION
`/etc/network/interfaces` file is modified such that it includes
a new file `/boot/octopi-network.txt` which contains sample config
snippets for getting wifi connectivity configured for WPA/WPA2-PSK,
WEP and unencrypted and also for a static IP on a virtual second
ethernet port.

This way after flashing the image to the SD the user can just
edit that file (which is on the root of the FAT partition which
desktop OSs should usually offer to access just when plugging in
the card), uncomment the matching configuration snippet, fill
in the credentials (SSID and password, or just the SSID in case
of an unencrypted WiFi), save, put the card in the Pi's SD card
slot and their USB WiFi dongle in a USB port, boot and have their
Pi directly on their network. No more cable needed, no problem
to quickly change the config when being on the move with the Pi.

Note that I tested this with the new 15-05-05 Raspbian image (that
includes that dhcpcd stuff), hence the "manual" mode on the wifi
config segments instead of "dhcp".

Test by flashing, editing the `octopi-network.txt` according to my
local WiFi setup, booting and verifying I could immediately connect.

Next step: netconnectd for everyone ;)