### PR TITLE
Suppress error when using restart command

### DIFF
--- a/src/filesystem/home/pi/.octoprint/config.yaml
+++ b/src/filesystem/home/pi/.octoprint/config.yaml
@@ -19,11 +19,17 @@ system:
     command: sudo shutdown -h now
     action: shutdown
     confirm: You are about to shutdown the system.
+    async: true
+    ignore: true
   - name: Reboot
     command: sudo shutdown -r now
     action: reboot
     confirm: You are about to reboot the system
+    async: true
+    ignore: true
   - name: Restart OctoPrint
     command: sudo service octoprint restart
     action: restart
     confirm: You are about to restart OctoPrint
+    async: true
+    ignore: true


### PR DESCRIPTION
When issuing one of the restart/reboot/shutdown commands
from the system menu, the request could not be acknowledged
anymore because the server was already gone, leading to the
client displaying an error for the command execution just
before the offline overlay.

To stop things like this from happening, 1.2.0 introduced
two new parameters for system actions, asnyc and ignore.

async makes the request return without waiting for the
result of the command's execution. ignore makes the client
ignore any errors in the command's execution.

The combination of both yields successful restarts/reboots/
shutdowns without scary messages.