### PR TITLE
README update: usage instructions & typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,18 +13,25 @@ Where to get it?
 
 Official mirror is `here <http://docstech.net/OctoPiMirror/>`_
 
-Nightly builds are avilable `here <http://docstech.net/OctoPiMirror/nightly/>`_
+Nightly builds are available `here <http://docstech.net/OctoPiMirror/nightly/>`_
 
 How to use it?
 --------------
 
-#. unzip the image and dd it to an sd card like any other Raspberry Pi image
-#. boot the pi and connect it to a lan or wifi network, like any other Rasbpian installation.
-#. OctoPrint is located at `http://octopi.local <http://octopi.local>`_ and also at `https://octopi.local <https://octopi.local>`_. Since the SSL certificate is self signed (and generated upon first boot), you will get a certificate warning at the latter location, please ignore it.
-#. If a webcam was plugged in, MJPG-streamer is on port 8080. You can reach it at: `http://octopi.local:8080/?action=stream <octopi.local:8080/?action=stream>`_. It is also setup so that you can reach it under `http://octopi.local/webcam/?action=stream <octopi.local/webcam/?action=stream>`_ and SSL respectively.
+#. Unzip the image and install it to an sd card `like any other Raspberry Pi image <https://www.raspberrypi.org/documentation/installation/installing-images/README.md>`_
+#. Configure your WiFi by editing ``octopi-network.txt`` on the root of the flashed card when using it like a thumb drive
+#. Boot the Pi from the card
+#. Log into your Pi via SSH (it is located at ``octopi.local`` `if your computer supports bonjour <https://learn.adafruit.com/bonjour-zeroconf-networking-for-windows-and-linux/overview>`_ or the IP address assigned by your router), default username is "pi", default password is "raspberry", change the password using the ``passwd`` command and expand the filesystem of the SD card through the corresponding option when running ``sudo raspi-config``.
+
+OctoPrint is located at `http://octopi.local <http://octopi.local>`_ and also at `https://octopi.local <https://octopi.local>`_. Since the SSL certificate is self signed (and generated upon first boot), you will get a certificate warning at the latter location, please ignore it.
+
+If a USB webcam or the Raspberry Pi camera is detected, MJPG-streamer will be started automatically as webcam server. OctoPrint on OctoPi ships with correctly configured stream and snapshot URLs pointing at it. If necessary, you can reach it under `http://octopi.local/webcam/?action=stream <octopi.local/webcam/?action=stream>`_ and SSL respectively, or directly on its configured port 8080: `http://octopi.local:8080/?action=stream <octopi.local:8080/?action=stream>`_.
+
+CuraEngine is installed and OctoPrint ships pre-configured with the correct path to utilize it for on-board-slicing. Just import a Cura Slicing Profile in OctoPrint's settings and start slicing directly on your Pi.
 
 Features
 --------
+
 * `OctoPrint <http://octoprint.org>`_ host software for 3d printers out of the box
 * `Raspbian <http://www.raspbian.org/>`_ tweaked for maximum preformance for printing out of the box
 * `mjpg-streamer with RaspiCam support <https://github.com/jacksonliam/mjpg-streamer>`_ for live viewing of prints and timelapse video creation.


### PR DESCRIPTION
Added some more steps to the usage instructions for the new
network setup mechanism and explained CuraEngine setup needs
slicing profile to be added by the user.

Also fixed typos where I stumbled over them.