### PR TITLE
Added mapper for network configuration

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -148,8 +148,12 @@ echo "start_x=1" >> /boot/config.txt
 echo "gpu_mem=128" >> /boot/config.txt
 
 # allow network configuration via /boot/octopi-network.txt
-sed -i "s@wpa-conf@# wpa-conf@g" /etc/network/interfaces
-sed -i "s@iface wlan@# iface wlan@g" /etc/network/interfaces
+sed -i "s@iface wlan0 @iface wlan0-raspbian @g" /etc/network/interfaces
+sed -i "s@iface wlan1 @iface wlan1-raspbian @g" /etc/network/interfaces
+echo "mapping wlan0" >> /etc/network/interfaces
+echo "  script /root/bin/map_iface" >> /etc/network/interfaces
+echo "mapping wlan1" >> /etc/network/interfaces
+echo "  script /root/bin/map_iface" >> /etc/network/interfaces
 echo "source /boot/octopi-network.txt" >> /etc/network/interfaces
 
 #unpack root in the end, so etc file are not overwritten, might need to add two roots int he future

--- a/src/filesystem/boot/octopi-network.txt
+++ b/src/filesystem/boot/octopi-network.txt
@@ -11,17 +11,17 @@
 # that matches your wifi setup and fill in SSID and passphrase.
 
 ## WPA/WPA2 secured
-#iface wlan0 inet manual
+#iface wlan0-octopi inet manual
 #    wpa-ssid "put SSID here"
 #    wpa-psk "put password here"
 
 ## WEP secured
-#iface wlan0 inet manual
+#iface wlan0-octopi inet manual
 #    wireless-essid "put SSID here"
 #    wireless-key "put password here"
 
 ## Open/unsecured
-#iface wlan0 inet manual
+#iface wlan0-octopi inet manual
 #    wireless-essid "put SSID here"
 #    wireless-mode managed
 

--- a/src/filesystem/home/root/bin/map_iface
+++ b/src/filesystem/home/root/bin/map_iface
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+IFACE=$1
+
+if grep -q "^\s*iface $IFACE-octopi " /boot/octopi-network.txt
+then
+	echo "$IFACE-octopi"
+	echo "Using /boot/octopi-network.txt for configuring $IFACE..." >> /var/log/map_iface.log
+else
+	echo "$IFACE-raspbian"
+	echo "Using original Raspbian configuration for configuring $IFACE..." >> /var/log/map_iface.log
+fi

--- a/src/filesystem/root/etc/logrotate.d/map_iface.log
+++ b/src/filesystem/root/etc/logrotate.d/map_iface.log
@@ -1,0 +1,10 @@
+/var/log/map_iface.log
+{
+    rotate 1
+    daily
+    missingok
+    notifempty
+    compress
+    delaycompress
+    sharedscripts
+}


### PR DESCRIPTION
Will decide between OctoPi and Raspbian type of network
configuration depending on whether the user set up a network
configuration in /boot/octopi-network.txt or not.

A mapping script will try to see if it can find an uncommented
line

  iface $IFACE-octopi

in /boot/octopi-network.txt. If so, the user obviously used this
method to setup their network credentials (the lines are usually
all commented out) and $IFACE will be mapped to use the
$IFACE-octopi definition from that file. If no such line is
found, $IFACE will be mapped to $IFACE-raspbian, which is the
default wlan0/wlan1 configuration shipped with vanilla Raspbian.

See also #122