### PR TITLE
Added wiringPi to image

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -119,6 +119,15 @@ pushd /home/pi
     adduser --system --disabled-password --disabled-login --home /var/lib/haproxy \
             --no-create-home --quiet --force-badname --group haproxy
   fi
+
+  if [ "$OCTOPI_INCLUDE_WIRINGPI" == "yes" ]
+  then
+    echo "--- Installing WiringPi"
+    gitclone OCTOPI_WIRINGPI_REPO wiringPi
+    pushd wiringPi
+      sudo -u pi ./build
+    popd
+  fi
   
 popd
 

--- a/src/config
+++ b/src/config
@@ -71,6 +71,11 @@ fi
 [ -n "$OCTOPI_HAPROXY_ARCHIVE" ] || OCTOPI_HAPROXY_ARCHIVE=http://www.haproxy.org/download/1.5/src/haproxy-$OCTOPI_HAPROXY_VERSION.tar.gz
 [ -n "$OCTOPI_INCLUDE_HAPROXY" ] || OCTOPI_INCLUDE_HAPROXY=yes
 
+# WiringPi
+[ -n "$OCTOPI_WIRINGPI_REPO_SHIP" ] || OCTOPI_WIRINGPI_REPO_SHIP=git://git.drogon.net/wiringPi
+[ -n "$OCTOPI_WIRINGPI_REPO_BUILD" ] || OCTOPI_WIRINGPI_REPO_BUILD=
+[ -n "$OCTOPI_WIRINGPI_REPO_BRANCH" ] || OCTOPI_WIRINGPI_REPO_BRANCH=master
+[ -n "$OCTOPI_INCLUDE_WIRINGPI" ] || OCTOPI_INCLUDE_WIRINGPI=yes
 
 ###############################################################################
 # Rewrite any build urls that are not yet set if we have a repository mirror

--- a/src/nightly_build_scripts/build_local_mirrors
+++ b/src/nightly_build_scripts/build_local_mirrors
@@ -3,4 +3,5 @@ git clone --mirror https://github.com/foosel/OctoPrint
 git clone --mirror https://github.com/jonaslorander/OctoPiPanel.git
 git clone --mirror https://github.com/jacksonliam/mjpg-streamer.git
 git clone --mirror https://github.com/tasanakorn/rpi-fbcp
+git clone --mirror git://git.drogon.net/wiringPi
 popd

--- a/src/nightly_build_scripts/octopi_nightly_build
+++ b/src/nightly_build_scripts/octopi_nightly_build
@@ -18,6 +18,7 @@ pushd ${OCTOPIPATH}
     export OCTOPI_OCTOPIPANEL_REPO_BUILD='http://localhost/git/OctoPiPanel.git/'
     export OCTOPI_FBCP_REPO_BUILD='http://localhost/git/rpi-fbcp.git/'
     export OCTOPI_MJPGSTREAMER_REPO_BUILD='http://localhost/git/mjpg-streamer.git/'
+    export OCTOPI_WIRINGPI_REPO_BUILD='http://localhost/git/wiringPi.git/'
     
     ${OCTOPIPATH}/src/build $1
     pushd src


### PR DESCRIPTION
`gpio` commands should work directly for toggling pins etc.

Should fix #51

@guysoft Please verify that the adjusted nightly build scripts are
ok this way, I use the source repositories directly instead of working
with mirrors. Not going to merge this until you confirm it is working for your setup.