### PR TITLE
Make oprint a non-system-side-package virtualenv

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -17,19 +17,23 @@ apt-get remove -y --purge scratch squeak-plugins-scratch squeak-vm wolfram-engin
 apt-get autoremove -y
 
 #apt-get octoprint virtualenv
-apt-get -y --force-yes install python2.7 python-virtualenv python-dev git screen libts-bin subversion cmake checkinstall avahi-daemon libavahi-compat-libdnssd1
+apt-get -y --force-yes install python2.7 python-virtualenv python-dev git screen libts-bin subversion cmake checkinstall avahi-daemon libavahi-compat-libdnssd1 libffi-dev libssl-dev
 
 pushd /home/pi
 
   #build virtualenv
-  sudo -u pi virtualenv --system-site-packages oprint
+  sudo -u pi virtualenv oprint
   
+  # first lets upgrade pip (the shipped version is way too old...)
+  sudo -u pi /home/pi/oprint/bin/pip install --upgrade pip
+
+  # we also want pyopenssl so we have a secure SSL context available
+  sudo -u pi /home/pi/oprint/bin/pip install pyopenssl ndg-httpsclient pyasn1 cryptography
+
   # OctoPrint & pyserial
   if [ "$OCTOPI_INCLUDE_OCTOPRINT" == "yes" ]
   then
     echo "--- Installing OctoPrint"
-    apt-get install -y --force-yes python-numpy python-netifaces
-    apt-get remove -y python-serial
 
     #pyserial that can handle non-standard baud rates
     sudo -u pi svn co http://pyserial.svn.sourceforge.net/svnroot/pyserial/trunk pyserial


### PR DESCRIPTION
This way we can use up to date versions of urllib3 etc that
do not have bugs...

This should solve #155 