### PR TITLE
Better size management for SD card image

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -180,6 +180,8 @@ unpack /filesystem/root /
 ### Disable GUI at start
 systemctl disable lightdm.service
 
+update-rc.d prepare_resize defaults
+
 ### OctoPrint
 
 if [ "$OCTOPI_INCLUDE_OCTOPRINT" == "yes" ]

--- a/src/config
+++ b/src/config
@@ -36,8 +36,16 @@ fi
 [ -n "$OCTOPI_CHROOT_SCRIPT_PATH" ] || OCTOPI_CHROOT_SCRIPT_PATH=$OCTOPI_SCRIPT_PATH/chroot_script
 [ -n "$OCTOPI_MOUNT_PATH" ] || OCTOPI_MOUNT_PATH=$OCTOPI_WORKSPACE/mount
 
+# if set will enlarge root parition prior to build by provided size in MB
+[ -n "$OCTOPI_IMAGE_ENLARGEROOT" ] || OCTOPI_IMAGE_ENLARGEROOT=
+
+# if set will resize root partition on image after build to minimum size + 
+# provided size in MB
+[ -n "$OCTOPI_IMAGE_RESIZEROOT" ] || OCTOPI_IMAGE_RESIZEROOT=
+
 [ -n "$OCTOPI_OVERRIDE_HOSTNAME" ] || OCTOPI_OVERRIDE_HOSTNAME=octopi
 
+# a git mirror to use for git clones instead of original remotes
 [ -n "$OCTOPI_BUILD_REPO_MIRROR" ] || OCTOPI_BUILD_REPO_MIRROR=
 
 # OctoPrint repo & branch

--- a/src/filesystem/boot/octopi.txt
+++ b/src/filesystem/boot/octopi.txt
@@ -1,3 +1,10 @@
+### Configure whether to automatically resize the SD on first boot
+#
+# Available options are:
+# - yes: perform resize
+# - no: don't perform resize
+perform_resize="yes"
+
 ### Configure which camera to use
 #
 # Available options are:

--- a/src/filesystem/root/etc/init.d/gencert
+++ b/src/filesystem/root/etc/init.d/gencert
@@ -35,7 +35,7 @@ case "$1" in
         # No-op
         ;;
   *)
-        echo "Usage: octopi_first_boot [start|stop]" >&2
+        echo "Usage: gencert [start|stop]" >&2
         exit 3
         ;;
 esac

--- a/src/filesystem/root/etc/init.d/prepare_resize
+++ b/src/filesystem/root/etc/init.d/prepare_resize
@@ -1,0 +1,46 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          prepare_resize
+# Required-Start:    $local_fs
+# Required-Stop:
+# Default-Start:     3
+# Default-Stop:
+# Short-Description: Prepare resize on first boot...
+# Description:
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+do_start () {
+  . /boot/octopi.txt
+
+  if [ "$perform_resize" != "yes" ]
+  then
+    log_failure_msg "Resize on boot is disabled"
+    exit 1
+  fi
+
+  /usr/bin/raspi-config --expand-rootfs >> /var/log/prepare_resize
+  /usr/sbin/update-rc.d prepare_resize remove >> /var/log/prepare_resize
+
+  log_success_msg "Resize prepared, rebooting to apply..."
+  /sbin/reboot
+}
+
+echo "First parameter is $1" >> /var/log/prepare_resize
+case "$1" in
+  start|"")
+        do_start
+        ;;
+  restart|reload|force-reload)
+        echo "Error: argument '$1' not supported" >&2
+        exit 3
+        ;;
+  stop)
+        # No-op
+        ;;
+  *)
+        echo "Usage: prepare_resize [start|stop]" >&2
+        exit 3
+        ;;
+esac

--- a/src/octopi
+++ b/src/octopi
@@ -37,6 +37,13 @@ pushd $OCTOPI_WORKSPACE
   fi
   unzip $OCTOPI_ZIP_IMG
   OCTOPI_IMG_PATH=`ls | grep .img`
+  export OCTOPI_BUILDBASE=$(basename $OCTOPI_IMG_PATH)
+
+  if [ -n "$OCTOPI_IMAGE_ENLARGEROOT" ]
+  then
+    # make our image a bit larger so we don't run into size problems...
+    enlarge_ext $OCTOPI_IMG_PATH 2 $OCTOPI_IMAGE_ENLARGEROOT
+  fi
 
   # mount root and boot partition
   mount_image $OCTOPI_IMG_PATH $OCTOPI_MOUNT_PATH
@@ -66,5 +73,11 @@ pushd $OCTOPI_WORKSPACE
   # unmount first boot, then root partition
   unmount_image $OCTOPI_MOUNT_PATH
   chmod 777 $OCTOPI_IMG_PATH
+
+  if [ -n "$OCTOPI_IMAGE_RESIZEROOT" ]
+  then
+    # resize image to minimal size + provided size
+    minimize_ext $OCTOPI_IMG_PATH 2 $OCTOPI_IMAGE_RESIZEROOT
+  fi
 popd
 


### PR DESCRIPTION
If `OCTOPI_IMAGE_ENLARGEROOT` is set to a size (in MB), the
root partition of the raspbian image will be enlarged by that
size before starting the actual build. This helps in situations
where the image doesn't ship with enough space to perform the build.

If `OCTOPI_IMAGE_RESIZEROOT` is set to a size (in MB), after the
build the image will be resized to its minimal size plus the provided
size. 200 MB appears to be a good value here.

On first boot the image now resizes itself to take up the full SD size unless
`perform_resize` is set to a value != `yes` in `/boot/octopi.txt`.