### PR TITLE
Allow specification of an additional pre/postscript

### DIFF
--- a/src/config
+++ b/src/config
@@ -4,7 +4,7 @@ CONFIG_DIR=$(dirname $(realpath -s $BASH_SOURCE))
 
 if [ -n "$VARIANT_CONFIG" ] && [ -f $VARIANT_CONFIG ]
 then
-  echo "Sourceing variant config $VARIANT_CONFIG..."
+  echo "Sourcing variant config $VARIANT_CONFIG..."
   source $VARIANT_CONFIG
 fi
 
@@ -26,6 +26,9 @@ fi
 
 ###############################################################################
 # All our config settings must start with OCTOPI_
+
+[ -n "$OCTOPI_PRESCRIPT" ] || OCTOPI_PRESCRIPT=
+[ -n "$OCTOPI_POSTSCRIPT" ] || OCTOPI_POSTSCRIPT=
 
 [ -n "$OCTOPI_SCRIPT_PATH" ] || OCTOPI_SCRIPT_PATH=$CONFIG_DIR
 [ -n "$OCTOPI_IMAGE_PATH" ] || OCTOPI_IMAGE_PATH=$OCTOPI_SCRIPT_PATH/image

--- a/src/octopi
+++ b/src/octopi
@@ -59,8 +59,16 @@ pushd $OCTOPI_WORKSPACE
     #make QEMU boot (remember to return)
     fixLd
     #sed -i 's@include /etc/ld.so.conf.d/\*.conf@\#include /etc/ld.so.conf.d/\*.conf@' etc/ld.so.conf
+
+    # if an additional pre-script is defined, execute that now
+    if [ -n "$OCTOPI_PRESCRIPT" ] && [ -f $OCTOPI_PRESCRIPT/chroot_script ]; then
+      echo "Injecting environment pre script from $OCTOPI_PRESCRIPT..."
+      execute_chroot_script $OCTOPI_PRESCRIPT $OCTOPI_PRESCRIPT/chroot_script
+    fi
+
     # if building a variant, execute its pre-chroot script
     if [ -n "$VARIANT_BASE" ] && [ -f $VARIANT_BASE/pre_chroot_script ]; then
+      echo "Injecting variant pre script from $VARIANT_BASE..."
       execute_chroot_script $VARIANT_BASE $VARIANT_BASE/pre_chroot_script
     fi
  
@@ -69,9 +77,16 @@ pushd $OCTOPI_WORKSPACE
     
     # if building a variant, execute its post-chroot script
     if [ -n "$VARIANT_BASE" ] && [ -f $VARIANT_BASE/post_chroot_script ]; then
+      echo "Injecting variant post script from $VARIANT_BASE..."
       execute_chroot_script $VARIANT_BASE $VARIANT_BASE/post_chroot_script
     fi
-    
+
+    # if an additional post-script is defined, execute that now
+    if [ -n "$OCTOPI_POSTSCRIPT" ] && [ -f $OCTOPI_POSTSCRIPT/chroot_script ]; then
+      echo "Injecting environment post script from $OCTOPI_POSTSCRIPT..."
+      execute_chroot_script $OCTOPI_POSTSCRIPT $OCTOPI_POSTSCRIPT/chroot_script
+    fi
+
     restoreLd
   popd
   


### PR DESCRIPTION
We might not want a custom variant for something like having to swap
resolv.conf or similar just to make the image buildable on certain
environments, so this adds a build environment specific additional means
to inject scripts into the build process.

Example: build server that requires a special set of nameservers in
/etc/resolv.conf during build.