### PR TITLE
Custom error page in haproxy for 503 error

### DIFF
--- a/src/filesystem/root/etc/haproxy/errors/503-no-octoprint.http
+++ b/src/filesystem/root/etc/haproxy/errors/503-no-octoprint.http
@@ -1,0 +1,111 @@
+HTTP/1.0 503 Service Unavailable
+Cache-Control: no-cache
+Connection: close
+Content-Type: text/html
+
+<html>
+    <head>
+        <title>OctoPrint is still starting</title>
+        <style>
+            body {
+                margin: 0;
+                font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+                font-size: 14px;
+                line-height: 20px;
+                color: #333333;
+                background-color: #ffffff;
+            }
+
+            code {
+                font-family: Monaco,Menlo,Consolas,"Courier New",monospace;
+                font-size: 12px;
+                border-radius: 3px;
+                padding: 2px 4px;
+                color: #d14;
+                white-space: nowrap;
+                background-color: #f7f7f7;
+                border: 1px solid #e1e1e8;
+            }
+
+            #startup-overlay {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                z-index: 10000;
+                display: block;
+            }
+
+            .background {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+            }
+
+            @media (max-width: 767px) {
+                .wrapper {
+                    padding: 20px;
+                }
+            }
+
+            @media (min-width: 768px) {
+                .wrapper {
+                    position: absolute;
+                    width: 750px;
+                    height: 400px;
+                    top: 50%;
+                    left: 50%;
+                    margin: -200px 0 0 -375px;
+                }
+            }
+
+            h1 {
+                line-height: 1.3;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="wrapper">
+            <h1>The OctoPrint server is currently not running</h1>
+
+            <p>
+                If you just started up your Raspberry Pi, please wait a couple of seconds, then
+                try to refresh this page.
+            </p>
+
+            <p>
+                If the issue persists, please log into your Raspberry Pi via SSH and check the following:
+            </p>
+
+            <ul>
+                <li>
+                    Verify that the process is running:
+                    <code>ps -ef | grep -i octoprint</code> should show a
+                    python process.
+                </li>
+                <li>
+                    If it isn't, the question is why. Take a look into
+                    <code>~/.octoprint/logs/octoprint.log</code>, there might
+                    be an error logged in there that helps to determine
+                    what's wrong.
+                </li>
+                <li>
+                    You might also want to try if you can restart the server
+                    (if no obvious error is visible):
+                    <code>sudo service octoprint restart</code>.
+                </li>
+            </ul>
+
+            <p>
+                If all that doesn't help to trouble shoot the issue, you can seek
+                support on the
+                <a href="https://groups.google.com/group/octoprint">OctoPrint Mailinglist</a>
+                or in the <a href="https://plus.google.com/communities/102771308349328485741">OctoPrint G+ Community</a>.
+            </p>
+        </div>
+    </body>
+</html>
+

--- a/src/filesystem/root/etc/haproxy/errors/503-no-octoprint.http
+++ b/src/filesystem/root/etc/haproxy/errors/503-no-octoprint.http
@@ -5,7 +5,7 @@ Content-Type: text/html
 
 <html>
     <head>
-        <title>OctoPrint is still starting</title>
+        <title>OctoPrint is currently not running</title>
         <style>
             body {
                 margin: 0;

--- a/src/filesystem/root/etc/haproxy/haproxy.cfg
+++ b/src/filesystem/root/etc/haproxy/haproxy.cfg
@@ -24,6 +24,7 @@ frontend public
         option forwardfor except 127.0.0.1
         use_backend webcam if { path_beg /webcam/ }
         default_backend octoprint
+        errorfile 503 /etc/haproxy/errors/503-no-octoprint.http
 
 backend octoprint
         reqrep ^([^\ :]*)\ /(.*) \1\ /\2


### PR DESCRIPTION
Should help users to understand why they are not seeing their
OctoPrint interface but instead an error from haproxy if the server
is not (yet) running.

![image](https://cloud.githubusercontent.com/assets/83657/12265838/c3b77ae8-b93f-11e5-8474-88cad7884710.png)
