### PR TITLE
added scripts for TouchUI boot-to-browser (7" touchscreen related)

### DIFF
--- a/src/filesystem/home/pi/scripts/boot-to-browser-touchui
+++ b/src/filesystem/home/pi/scripts/boot-to-browser-touchui
@@ -1,0 +1,62 @@
+#!/bin/bash
+#!/bin/bash -x
+
+# based on steps found at
+#   https://github.com/BillyBlaze/OctoPrint-TouchUI/wiki/Setup:-Boot-to-Browser
+
+#   TODO
+# -----------------------------------
+#  - Add proper detection of TouchUI plugin
+#  - Add tweaks found in
+#       https://github.com/BillyBlaze/OctoPrint-TouchUI/wiki/Tweaks:-Iceweasel
+#
+
+echo ""
+echo "Setting up boot-to-browser, do not turn off your Pi during this process!"
+echo ""
+echo "Note: Assumes Pi is configured to boot to command line"
+echo "Note: Assumes Touch UI plugin is already installed"
+echo ""
+
+# this is a kludge that needs to be fixed to properly check if plugin is currently installed
+if grep -q 'Successfully installed TouchUI' ~/.octoprint/logs/plugin_pluginmanager_console.log; then
+    echo Saw TouchUI was installed 
+else
+    echo ERROR: TouchUI Plugin not found.  Exiting.
+    exit 1
+fi
+
+# bring system up to date
+sudo apt-get update
+sudo apt-get -y upgrade
+
+
+# Install X.org, iceweasel and stuff:
+sudo apt-get install -y matchbox xinit x11-xserver-utils unclutter iceweasel
+
+
+# Get the TouchUI boot files:
+wget -P /home/pi/ https://github.com/BillyBlaze/OctoPrint-TouchUI/archive/autostart.zip
+# this will create a OctoPrint-TouchUI-autostart directory
+unzip -d /home/pi/ /home/pi/autostart.zip
+
+
+# Copy service file and register it as auto boot:
+sudo cp /home/pi/OctoPrint-TouchUI-autostart/touchui.init /etc/init.d/touchui
+sudo chmod +x /etc/init.d/touchui
+sudo update-rc.d touchui defaults
+
+
+# this is like `sudo dpkg-reconfigure x11-common` to allow Anybody to run xinit.
+sudo sed -i \
+    's/allowed_users=console/allowed_users=anybody/' /etc/X11/Xwrapper.config
+
+
+# can safely remove the downloaded autostart.zip
+rm /home/pi/autostart.zip
+
+
+echo ""
+echo "Reboot your Pi to have it boot to Touch UI."
+echo "    sudo reboot"
+echo ""

--- a/src/filesystem/home/pi/scripts/boot-to-browser-touchui
+++ b/src/filesystem/home/pi/scripts/boot-to-browser-touchui
@@ -4,27 +4,33 @@
 # based on steps found at
 #   https://github.com/BillyBlaze/OctoPrint-TouchUI/wiki/Setup:-Boot-to-Browser
 
-#   TODO
+#   TODO?
 # -----------------------------------
-#  - Add proper detection of TouchUI plugin
 #  - Add tweaks found in
 #       https://github.com/BillyBlaze/OctoPrint-TouchUI/wiki/Tweaks:-Iceweasel
 #
 
 echo ""
 echo "Setting up boot-to-browser, do not turn off your Pi during this process!"
-echo ""
-echo "Note: Assumes Pi is configured to boot to command line"
-echo "Note: Assumes Touch UI plugin is already installed"
+echo "NOTE: Assumes Pi is configured to boot to command line"
 echo ""
 
-# this is a kludge that needs to be fixed to properly check if plugin is currently installed
-if grep -q 'Successfully installed TouchUI' ~/.octoprint/logs/plugin_pluginmanager_console.log; then
-    echo Saw TouchUI was installed 
+# determine directory script is running in
+#    via http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Run python script to determine whether plugin is installed
+plugin_status_py="$DIR/plugin_status.py"
+"$plugin_status_py" touchui
+exit_code=$?
+if [ $exit_code -eq 0 ]
+then
+    echo "Saw TouchUI plugin was enabled"
 else
-    echo ERROR: TouchUI Plugin not found.  Exiting.
+    echo "ERROR: TouchUI Plugin not found enabled. (Code: $exit_code)" >&2
     exit 1
 fi
+
 
 # bring system up to date
 sudo apt-get update

--- a/src/filesystem/home/pi/scripts/plugin_status.py
+++ b/src/filesystem/home/pi/scripts/plugin_status.py
@@ -1,0 +1,64 @@
+#!/home/pi/oprint/bin/python
+# coding=utf-8
+from __future__ import absolute_import
+
+__author__ = "David Crook <dpcrook@users.noreply.github.com>"
+__license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
+__copyright__ = "Copyright (C) 2016 The OctoPrint Project - Released under terms of the AGPLv3 License"
+
+# plugin_status.py - Script to determine if a plugin is enabled in OctoPrint
+
+# Returns an exit code for shell script:
+#  - 0: Plugin is enabled
+#  - 1: Plugin is not enabled
+# 
+# USAGE
+#
+#   # check by default for 'touchui' plugin
+#   plugin_status.py
+#
+#   # check for 'pluginmanager' plugin
+#   plugin_status.py pluginmanager
+#
+#   # returns exit code of 1 for plugin not enabled
+#   plugin_status.py nonexistent
+#   echo $0
+#
+
+import sys
+
+from octoprint.settings import settings
+import octoprint.plugin
+
+DEBUG = False
+#DEBUG = True
+
+# see if a command line argument was used
+plugin_name = 'touchui'
+if sys.argv[1:]:
+    plugin_name = sys.argv[1]
+
+# initialize settings object (required by plugin_manager)
+s = settings(init=True, basedir=None, configfile=None)
+pluginManager = octoprint.plugin.plugin_manager(init=True) 
+
+if DEBUG:
+    print pluginManager.enabled_plugins
+
+if plugin_name in pluginManager.enabled_plugins:
+    print "Plugin '" + plugin_name + "' found enabled"
+    sys.exit(0)
+else:
+    print "Plugin '" + plugin_name + "' NOT found enabled"
+    sys.exit(1)
+
+
+
+# ======================================================================
+# Some helpful files and commands I used to investigate
+#
+# OctoPrint/src/octoprint/server/__init__.py
+# grep -R 'Server(' OctoPrint/src/octoprint
+# OctoPrint/src/octoprint/__init__.py
+# grep -R 'Main(' OctoPrint/src/octoprint
+


### PR DESCRIPTION
#189

related to issue #189 (add support for the official PiTFT 7" touch screen) 

scriptified steps in [TouchUI plugin boot to browser](https://github.com/BillyBlaze/OctoPrint-TouchUI/wiki/Setup:-Boot-to-Browser)

Changes made in `OctoPi/src/filesystem/home/pi/scripts`
Added:
- `boot-to-browser-touchui` bash script
- `plugin_status.py` python script
