### PR TITLE
Better "service not running" error pages

### DIFF
--- a/src/filesystem/root/etc/haproxy/errors/503-no-octoprint.http
+++ b/src/filesystem/root/etc/haproxy/errors/503-no-octoprint.http
@@ -27,22 +27,14 @@ Content-Type: text/html
                 border: 1px solid #e1e1e8;
             }
 
-            #startup-overlay {
-                position: fixed;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
-                z-index: 10000;
-                display: block;
-            }
-
-            .background {
-                position: fixed;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
+            pre {
+                font-family: Monaco,Menlo,Consolas,"Courier New",monospace;
+                font-size: 12px;
+                border-radius: 3px;
+                padding: 2px 4px;
+                white-space: nowrap;
+                background-color: #f7f7f7;
+                border: 1px solid #e1e1e8;
             }
 
             @media (max-width: 767px) {
@@ -55,10 +47,10 @@ Content-Type: text/html
                 .wrapper {
                     position: absolute;
                     width: 750px;
-                    height: 400px;
+                    height: 450px;
                     top: 50%;
                     left: 50%;
-                    margin: -200px 0 0 -375px;
+                    margin: -225px 0 0 -375px;
                 }
             }
 
@@ -83,8 +75,11 @@ Content-Type: text/html
             <ul>
                 <li>
                     Verify that the process is running:
-                    <code>ps -ef | grep -i octoprint</code> should show a
-                    python process.
+                    <code>ps -ef | grep -i octoprint | grep -i python</code> should show a
+                    python process:
+                    <pre>pi@octopi:~ $ ps -ef | grep -i octoprint | grep -i python<br>
+pi        1441     1  6 11:12 ?        00:00:15 /home/pi/oprint/bin/python <br>
+/home/pi/oprint/bin/octoprint --host=127.0.0.1 --port=5000</pre>
                 </li>
                 <li>
                     If it isn't, the question is why. Take a look into
@@ -104,6 +99,9 @@ Content-Type: text/html
                 support on the
                 <a href="https://groups.google.com/group/octoprint">OctoPrint Mailinglist</a>
                 or in the <a href="https://plus.google.com/communities/102771308349328485741">OctoPrint G+ Community</a>.
+                Please provide your OctoPi <strong>and</strong> OctoPrint versions, your <code>octoprint.log</code> 
+                (in form of a <a href="http://pastebin.com/" target="_blank">pastebin link</a>) and explain what you 
+                already tried and observed as detailed as possible.
             </p>
         </div>
     </body>

--- a/src/filesystem/root/etc/haproxy/errors/503-no-webcam.http
+++ b/src/filesystem/root/etc/haproxy/errors/503-no-webcam.http
@@ -1,0 +1,114 @@
+HTTP/1.0 503 Service Unavailable
+Cache-Control: no-cache
+Connection: close
+Content-Type: text/html
+
+<html>
+    <head>
+        <title>Webcam server is currently not running</title>
+        <style>
+            body {
+                margin: 0;
+                font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+                font-size: 14px;
+                line-height: 20px;
+                color: #333333;
+                background-color: #ffffff;
+            }
+
+            code {
+                font-family: Monaco,Menlo,Consolas,"Courier New",monospace;
+                font-size: 12px;
+                border-radius: 3px;
+                padding: 2px 4px;
+                color: #d14;
+                white-space: nowrap;
+                background-color: #f7f7f7;
+                border: 1px solid #e1e1e8;
+            }
+
+            pre {
+                font-family: Monaco,Menlo,Consolas,"Courier New",monospace;
+                font-size: 12px;
+                border-radius: 3px;
+                padding: 2px 4px;
+                white-space: nowrap;
+                background-color: #f7f7f7;
+                border: 1px solid #e1e1e8;
+            }
+
+            @media (max-width: 767px) {
+                .wrapper {
+                    padding: 20px;
+                }
+            }
+
+            @media (min-width: 768px) {
+                .wrapper {
+                    position: absolute;
+                    width: 750px;
+                    height: 600px;
+                    top: 50%;
+                    left: 50%;
+                    margin: -300px 0 0 -375px;
+                }
+            }
+
+            h1 {
+                line-height: 1.3;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="wrapper">
+            <h1>The webcam server is currently not running</h1>
+
+            <p><strong>
+                If you do not have a camera attached, this is normal and can be safely ignored. 
+            </strong></p>
+
+            <p>
+                Otherwise, if you just started up your Raspberry Pi or just plugged in your camera, 
+                please wait a couple of seconds.
+            </p>
+
+            <p>
+                If the issue persists, please check the following:
+            </p>
+
+            <ul>
+                <li>
+                    If you have a Raspberry Pi camera, verify that it is properly attached. The ribbon 
+                    cable can be plugged in the wrong way. <strong>Power off your Pi first, do not attempt
+                    to attach or detach the Raspberry Pi camera while the Pi is powered!</strong>
+                </li>
+                <li>
+                    If you have a USB camera, it might be that it does not support MJPG (Motion JPEG) natively and needs the
+                    <code>-y</code> parameter to work. Try <a href="https://github.com/foosel/OctoPrint/wiki/FAQ#how-can-i-change-the-webcam-resolution-on-octopi" target="_blank">editing <code>octopi.txt</code></a>,
+                    add <code>-y</code> to <code>camera_usb_options</code> and make sure to remove the leading <code>#</code>, e.g.:
+                    <pre>camera_usb_options="-r 640x480 -f 10 -y"</pre>
+                    Reboot your Raspberry Pi with the camera attached and see if that makes it work.<br>
+                    <strong>Note</strong>: If your camera doesn't support MJPG natively, the webcam server will have to use valuable
+                    system resources to transcode the camera stream which could be better used for printing. Consider 
+                    getting a camera that does support MJPG natively.
+                </li>
+                <li>
+                    Log into your Raspberry Pi via SSH. Check if your camera is detected by the system via <code>lsusb</code>.
+                    If it is check what the webcam server is reporting in <code>/var/log/webcamd.log</code>, there might be an
+                    error logged in there that helps to determine what's wrong.
+                </li>
+            </ul>
+
+            <p>
+                If all that doesn't help to trouble shoot the issue, you can seek
+                support on the
+                <a href="https://groups.google.com/group/octoprint">OctoPrint Mailinglist</a>
+                or in the <a href="https://plus.google.com/communities/102771308349328485741">OctoPrint G+ Community</a>.
+                Please provide your camera model, <code>lsusb</code> output and <code>/var/log/webcamd.log</code> (as a 
+                <a href="http://pastebin.com/" target="_blank">pastebin link</a>) and explain what you 
+                already tried and observed as detailed as possible.
+            </p>
+        </div>
+    </body>
+</html>
+

--- a/src/filesystem/root/etc/haproxy/haproxy.cfg
+++ b/src/filesystem/root/etc/haproxy/haproxy.cfg
@@ -24,14 +24,16 @@ frontend public
         option forwardfor except 127.0.0.1
         use_backend webcam if { path_beg /webcam/ }
         default_backend octoprint
-        errorfile 503 /etc/haproxy/errors/503-no-octoprint.http
 
 backend octoprint
         reqrep ^([^\ :]*)\ /(.*) \1\ /\2
         reqadd X-Scheme:\ https if { ssl_fc }
         option forwardfor
         server octoprint1 127.0.0.1:5000
+        errorfile 503 /etc/haproxy/errors/503-no-octoprint.http
 
 backend webcam
         reqrep ^([^\ :]*)\ /webcam/(.*)     \1\ /\2
         server webcam1  127.0.0.1:8080
+        errorfile 503 /etc/haproxy/errors/503-no-webcam.http
+


### PR DESCRIPTION
Currently the "OctoPrint server not running" page will also be shown when navigating to the `/webcam` path (e.g. to check the webcam server manually outside of OctoPrint), and imply the OctoPrint server being down when in fact it's the webcam server that's down. This solves that issue, improves on the troubleshooting steps for the "OctoPrint server down" situation and adds a whole new error page including troubleshooting steps for the "webcam server down" situation.

In a nutshell:

  * Better wording on existing "OctoPrint server not running" error page
  * New error page for "Webcam server not running"
  * configuration change in haproxy to show octoprint one only for
    503 in OctoPrint backend and webcam one only for 503 in webcam
    backend. 
  * Also removed some unused CSS from the error pages themselves