### PR TITLE
Corrected the IP address in the network settings instructions

### DIFF
--- a/src/filesystem/boot/octopi-network.txt
+++ b/src/filesystem/boot/octopi-network.txt
@@ -41,7 +41,7 @@
 #
 # You can then reach the Pi from the system's browser by going to
 #
-#   http://192.168.250.1
+#   http://192.168.250.10
 #
 # or
 #


### PR DESCRIPTION
It might lend to confusion when the static IP address is set to `192.168.250.10` and then suggested that the system can be reached from `192.168.250.1`, this is obviously a typo.