### PR TITLE
changed vagrant box to "wzurowski/vivid64"... 

### DIFF
--- a/src/vagrant/Vagrantfile
+++ b/src/vagrant/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |o|
     # o.vm.box = "octopi-build"
-    o.vm.box= "https://github.com/kraksoft/vagrant-box-ubuntu/releases/download/15.04/ubuntu-15.04-amd64.box"
+    o.vm.box= "wzurowski/vivid64"
     o.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
     o.vm.synced_folder "../../", "/OctoPi", create:true, type: "nfs"
     o.vm.network :private_network, ip: "192.168.55.55"


### PR DESCRIPTION
which has the guest additions installed.

This is nesacerry because the old box was not able to provision right due to problems with mounting. See issue #264.