### PR TITLE
Adjusted config.yaml to match layout of OctoPrint 1.3.x

### DIFF
--- a/src/filesystem/home/pi/.octoprint/config.yaml
+++ b/src/filesystem/home/pi/.octoprint/config.yaml
@@ -11,25 +11,8 @@ plugins:
     checks:
       octoprint:
         update_folder: /home/pi/OctoPrint
-    octoprint_restart_command: sudo service octoprint restart
-    environment_restart_command: sudo shutdown -r now
-system:
-  actions:
-  - name: Shutdown
-    command: sudo shutdown -h now
-    action: shutdown
-    confirm: You are about to shutdown the system.
-    async: true
-    ignore: true
-  - name: Reboot
-    command: sudo shutdown -r now
-    action: reboot
-    confirm: You are about to reboot the system
-    async: true
-    ignore: true
-  - name: Restart OctoPrint
-    command: sudo service octoprint restart
-    action: restart
-    confirm: You are about to restart OctoPrint
-    async: true
-    ignore: true
+server:
+  commands:
+    systemShutdownCommand: sudo shutdown -h now
+    systemRestartCommand: sudo shutdown -r now
+    serverRestartCommand: sudo service octoprint restart


### PR DESCRIPTION
Some things were switched around in OctoPrint, doesn't make sense to ship with the old config.yaml layout (even though it would be automigrated).