### PR TITLE
Adjusted init script to new OctoPrint CLI

### DIFF
--- a/src/filesystem/root/etc/init.d/octoprint
+++ b/src/filesystem/root/etc/init.d/octoprint
@@ -16,8 +16,8 @@
 # Author: Sami Olmari
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DESC="Octoprint Daemon"
-NAME="Octoprint"
+DESC="OctoPrint Daemon"
+NAME="OctoPrint"
 DAEMON=/usr/bin/octoprint
 PIDFILE=/var/run/$NAME.pid
 PKGNAME=octoprint
@@ -73,7 +73,7 @@ do_start()
 
    if [ $RETVAL != 0 ]; then
        start-stop-daemon --start --background --quiet --pidfile $PIDFILE --make-pidfile \
-       --exec $DAEMON --chuid $OCTOPRINT_USER --user $OCTOPRINT_USER --umask $UMASK -- $DAEMON_ARGS
+       --exec $DAEMON --chuid $OCTOPRINT_USER --user $OCTOPRINT_USER --umask $UMASK -- serve $DAEMON_ARGS
        RETVAL="$?"
    fi
 }


### PR DESCRIPTION
Running in foreground mode requires "serve" keyword since 1.3.0. Still works without, but logs a warning to console.

Also fixed a couple of misspellings of OctoPrint in the init file while at it (capital P in the middle!) ;)