### PR TITLE
Make CLI a bit more helpful for newbies

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -214,6 +214,9 @@ EOT
 [ -f /etc/ifplugd/action.d/ifupdown ] && mv /etc/ifplugd/action.d/ifupdown /etc/ifplugd/action.d/ifupdown.original
 [ -f /etc/wpa_supplicant/ifupdown.sh ] && ln -s /etc/wpa_supplicant/ifupdown.sh /etc/ifplugd/action.d/ifupdown
 
+# add a longer welcome text to ~pi/.bashrc
+echo "source /home/pi/scripts/welcome" >> /home/pi/.bashrc
+
 #unpack root in the end, so etc file are not overwritten, might need to add two roots int he future
 unpack /filesystem/root /
 

--- a/src/filesystem/home/pi/scripts/welcome
+++ b/src/filesystem/home/pi/scripts/welcome
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+_IP=$(hostname -I)
+_OCTOPRINT_VERSION=$(/home/pi/oprint/bin/python -c "from octoprint._version import get_versions; print(get_versions()['version'])" || echo "unknown")
+_OCTOPI_VERSION=$(cat /etc/octopi_version || echo "unknown")
+
+echo
+echo "------------------------------------------------------------------------------"
+echo "Access OctoPrint from a web browser on your network by navigating to any of:"
+echo
+echo "    http://octopi.local"
+
+for ip in $_IP;
+do
+    echo "    http://$ip"
+done
+
+echo
+echo "https is also available, with a self-signed certificate."
+
+if ! which lightdm 2>&1 >/dev/null;
+then
+    echo "------------------------------------------------------------------------------"
+    echo "This image comes without a desktop environment installed because it's not "
+    echo "required for running OctoPrint. If you want a desktop environment you can "
+    echo "install it via"
+    echo
+    echo "    sudo /home/pi/scripts/install-desktop"
+fi
+
+echo "------------------------------------------------------------------------------"
+echo "OctoPrint version : $_OCTOPRINT_VERSION"
+echo "OctoPi version    : $_OCTOPI_VERSION"
+echo "------------------------------------------------------------------------------"
+echo


### PR DESCRIPTION
Two commits doing the following (provided as a single PR because otherwise you'd have to resolve a conflict for merging - the third commit - and they are pretty related):

### 	Add "how to use" instructions to boot screen

A lot of people appear to get confused when they boot up OctoPi with a screen attached and are then greeted by a command line login instead of OctoPrint.

Therefore added instructions to please use a browser to connect to a list of potential addresses to access OctoPrint - that might help.

### 	Added welcome text to login/bashrc

Upon logging in via command line, the user will now get the following information:

  * IPs/URLs to access OctoPrint
  * Hint how to install desktop environment if not already
    installed
  * Versions of OctoPrint and OctoPi

Looks like this:

```
The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Mon Mar  6 18:33:27 2017 from 192.168.1.3

------------------------------------------------------------------------------
Access OctoPrint from a web browser on your network by navigating to any of:

    http://octopi.local
    http://192.168.1.151

https is also available, with a self-signed certificate.
------------------------------------------------------------------------------
This image comes without a desktop environment installed because it's not
required for running OctoPrint. If you want a desktop environment you can
install it via

    sudo /home/pi/scripts/install-desktop
------------------------------------------------------------------------------
OctoPrint version : 1.3.1
OctoPi version    : 0.14.0
------------------------------------------------------------------------------

pi@octopi:~ $
```

or this if a desktop environment is already installed:

```
The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Mon Mar  6 18:33:27 2017 from 192.168.1.3

------------------------------------------------------------------------------
Access OctoPrint from a web browser on your network by navigating to any of:

    http://octopi.local
    http://192.168.1.151

https is also available, with a self-signed certificate.
------------------------------------------------------------------------------
OctoPrint version : 1.3.1
OctoPi version    : 0.14.0
------------------------------------------------------------------------------

pi@octopi:~ $
```
