### PR TITLE
Prevent NTP updates from failing on RPi3 wifi

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -238,6 +238,10 @@ echo
 echo "------------------------------------------------------------"
 echo
 EOT
+
+# prevent ntp updates from failing due to some Rpi3 weirdness, see also "Fix SSH" further below
+echo '/sbin/iptables -t mangle -I POSTROUTING 1 -o wlan0 -p udp --dport 123 -j TOS --set-tos 0x00' >> /etc/rc.local
+
 echo 'exit 0' >> /etc/rc.local
 
 # add a longer welcome text to ~pi/.bashrc


### PR DESCRIPTION
While I couldn't reproduce this issue on a current build, apparently
it doesn't necessarily have to happen always and the corresponding
ticket on the rpi bug tracker (raspberrypi/linux#1519) is still
open as well.

Hence this change. As documented at

  https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=141454

and other locations, ntp updates on RPi3 (sometimes?) fail if the
built-in WiFi interface is used. This appears to be the same issue
or at least related to SSH not properly functioning as described
in #294 and also documented in raspberrypi/linux#1519.

A wrong system date of the underlying OS will cause issues with
SSL handshakes, which in turn will produce fatal errors when
attempting to install plugins (see foosel/OctoPrint#1827) or
probably also when updating either OctoPrint or the system itself.
Basically anything that does certificate validity checks will fall
on its face.

Having the Pi properly set its system date is hence crucial for
operation, so we need to make sure ntp can do its job.

This might also affect RPiZeroW - I haven't observed the issue
with a current build there though.