### PR TITLE
Service file to fix symlink for wpa_supplicant.conf

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -232,6 +232,8 @@ systemctl_if_exists disable lightdm.service
 update-rc.d change_password defaults
 update-rc.d change_hostname defaults
 
+systemctl_if_exists enable check_wpa_link.service
+
 ### Fix SSH
 echo "IPQoS 0x00" >> /etc/ssh/sshd_config
 

--- a/src/filesystem/home/root/bin/check_wpa_link
+++ b/src/filesystem/home/root/bin/check_wpa_link
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+link_source="/etc/wpa_supplicant/wpa_supplicant.conf"
+link_target="/boot/octopi-wpa-supplicant.txt"
+
+if ! [ -L $link_source ] && [ -f $link_target ]
+then
+  # wpa_supplicant.conf is not a link, link target exists
+  echo "Symlink from $link_source to $link_target has been broken, attempting restore"
+
+  if [ -f $link_source ]
+  then
+    # wpa_supplicant.conf exists but symlink has been removed. This can happen when
+    # the wifi country setting is changed through raspi-config (for versions of that
+    # older than early april 2017). See also guysoft/OctoPi#336
+    #
+    # We'll now attempt to parse the current wifi country from wpa_supplicant.conf,
+    # apply it to our link target, remove the wpa_supplicant and then recreate the 
+    # symlink.
+
+    if grep -q "^country=" $link_source ; then
+      echo "Wifi country setting detected in $link_source, will copy"
+
+      # parse country setting from wpa_supplicant.conf - this is adapted from raspi-config
+      country=`grep country= $link_source | cut -d "=" -f 2`
+
+      # apply it to link target - this is adapted from raspi-config
+      if grep -q "^country=" $link_target ; then
+        sed -i --follow-symlinks "s/^country=.*/country=$country/g" $link_target
+      else
+        sed -i --follow-symlinks "1i country=$country" $link_target
+      fi
+
+      echo "Copied wifi country setting $country to $link_target"
+    fi
+
+    # remove wpa_supplicant.conf and recreate symlink
+    rm $link_source
+    ln -s $link_target $link_source
+    echo "Restored link from $link_source to $link_target"
+  else
+    # wpa_supplicant.conf is missing completely, recreate symlink
+    ln -s $link_target $link_source
+    echo "Restored link from $link_source to $link_target"
+  fi
+fi

--- a/src/filesystem/root/etc/systemd/system/check_wpa_link.service
+++ b/src/filesystem/root/etc/systemd/system/check_wpa_link.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Check that wpa-supplicant.conf is a symlink
+
+DefaultDependencies=no
+
+Before=network-pre.target
+Wants=network-pre.target
+
+After=local-fs.target
+Wants=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/root/bin/check_wpa_link
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Included script will make sure that if wpa_supplicant.conf is no
longer a symlink but it and /boot/octopi-wpa-supplicant.txt exist,
the selected wifi country will be extracted and written to
/boot/octopi-wpa-supplicant.txt and then the symlink will be
recreated. If wpa_supplicant.conf is completely gone, only the
symlink will be recreated. Nothing will be done if
/boot/octopi-wpa-supplicant.txt does not exist.

The service file ensures that this check is done on every boot,
after the local file system becomes available but before the
networking gets initialized.

This should solve #336

Note that this requires systemd (Debian Jessie) - since current
Raspbian starts SysV init scripts only after networking has
started to initialized, it was impossible for me to create a
SysV init script that fixes the symlink prior to network
initialization.