### PR TITLE
Do not allow passwordless sudo for user pi

### DIFF
--- a/src/config
+++ b/src/config
@@ -1,4 +1,4 @@
 export DIST_NAME=OctoPi
 export DIST_VERSION=0.15
-export MODULES="base(raspicam, network, disable-services(octopi))"
+export MODULES="base(raspicam, network, disable-services(octopi), password-for-sudo)"
 


### PR DESCRIPTION
Raspbian ships it by default this way and that's a really bad idea with regards to security. Sure, if an 
attacker already logged in through SSH because the user didn't change their password as suggested, 
an additional password request for a malicious sudo won't help either. But since we also have plugin system in OctoPrint, a system command editor and various other means for configuring command lines, we don't want to make abusing those too easy.

Note: Also adjusted the existing sudoers files for allowing service and shutdown (through OctoPrint) - turns out it's no longer /sbin/service but /usr/sbin/service now and to be safe we are now using which here

@guysoft This is something that has made me very very uncomfortable for a while now and I'd really feel better if sudo wasn't generally passwordless in OctoPi anymore ASAP. But I could understand if you want to wait with merging this until after the release - even though I think that it shouldn't be too critical - and am also happy to discuss this addition (or rather removal) more. 