### PR TITLE
Custom webroot & disabled controls for webcam server

### DIFF
--- a/src/chroot_script
+++ b/src/chroot_script
@@ -93,6 +93,23 @@ pushd /home/pi
     pushd mjpg-streamer
       mv mjpg-streamer-experimental/* .
       sudo -u pi make
+
+      # create our custom web folder and add a minimal index.html to it
+      sudo -u pi mkdir www-octopi
+      pushd www-octopi
+        cat <<EOT >> index.html
+<html>
+<head><title>mjpg_streamer test page</title></head>
+<body>
+<h1>Snapshot</h1>
+<p>Refresh the page to refresh the snapshot</p>
+<img src="./?action=snapshot" alt="Snapshot">
+<h1>Stream</h1>
+<img src="./?action=stream" alt="Stream">
+</body>
+</html>
+EOT
+      popd
     popd
   fi
   

--- a/src/filesystem/boot/octopi.txt
+++ b/src/filesystem/boot/octopi.txt
@@ -38,9 +38,10 @@
 #
 # If this fixes your problem, please report it back so we can include the device
 # out of the box.
+#
 #additional_brokenfps_usb_devices=("046d:082b" "aabb:ccdd")
 
-### additional options to supply to MJPG Streamer for the RasPi Cam
+### Additional options to supply to MJPG Streamer for the RasPi Cam
 #
 # See https://github.com/foosel/OctoPrint/wiki/MJPG-Streamer-configuration
 # for available options
@@ -48,3 +49,17 @@
 # Defaults to 10fps
 #
 #camera_raspi_options="-fps 10"
+
+### Configuration of camera HTTP output
+#
+# Usually you should NOT need to change this at all! Only touch if you
+# know what you are doing and what the parameters mean.
+#
+# Below settings are used in the mjpg-streamer call like this:
+#
+#   -o "output_http.so -w $camera_http_webroot $camera_http_options"
+#
+# Current working directory is the mjpg-streamer base directory.
+#
+#camera_http_webroot="./www-octopi"
+#camera_http_options="-n"

--- a/src/filesystem/home/root/bin/webcamd
+++ b/src/filesystem/home/root/bin/webcamd
@@ -19,6 +19,8 @@ MJPGSTREAMER_INPUT_RASPICAM="input_raspicam.so"
 camera="auto"
 camera_usb_options="-r 640x480 -f 10"
 camera_raspi_options="-fps 10"
+camera_http_webroot="./www-octopi"
+camera_http_options="-n"
 additional_brokenfps_usb_devices=()
 
 if [ -e "/boot/octopi.txt" ]; then
@@ -47,8 +49,8 @@ function goodbye() {
 function runMjpgStreamer {
     input=$1
     pushd $MJPGSTREAMER_HOME > /dev/null 2>&1
-        echo Running ./mjpg_streamer -o "output_http.so -w ./www" -i "$input"
-        LD_LIBRARY_PATH=. ./mjpg_streamer -o "output_http.so -w ./www" -i "$input" &
+        echo Running ./mjpg_streamer -o "output_http.so -w $camera_http_webroot $camera_http_options" -i "$input"
+        LD_LIBRARY_PATH=. ./mjpg_streamer -o "output_http.so -w $camera_http_webroot $camera_http_options" -i "$input" &
         wait
     popd > /dev/null 2>&1
 }
@@ -108,6 +110,7 @@ echo "--- Configuration: ----------------------------"
 echo "camera:        $camera"
 echo "usb options:   $camera_usb_options"
 echo "raspi options: $camera_raspi_options"
+echo "http options:  -w $camera_http_webroot $camera_http_options"
 echo "-----------------------------------------------"
 echo ""
 


### PR DESCRIPTION
Instead of ./www we now use ./www-octopi by default which only
contains an index.html (generated during image build) that displays
only the snapshot and stream for debugging purposes.

The command action on mjpg-streamer (which control.html of the stock
webroot utilizes) has also been disabled via "-n".

Two new variables have been introduced in /boot/octopi.txt to
allow configuring the webroot to use and the additional options
for output_http.so (by default only "-n"), in case power users
need to change back or otherwise customize stock behaviour.

Closes #358