### PR TITLE
Add instructions on how to remove git wrapper

### DIFF
--- a/src/modules/octopi/filesystem/home/root/bin/git
+++ b/src/modules/octopi/filesystem/home/root/bin/git
@@ -2,7 +2,14 @@
 
 if [ "$(id -u)" == "0" ]
 then
-  echo "Please run git without sudo, your regular user account is enough :)" 2>&1
+  echo "Please do not run git as root, your regular user account is enough :)"
+  echo
+  echo "If you need to run git with root rights for some other application than"
+  echo "what comes preinstalled on this image you can remove this sanity check:"
+  echo
+  echo "    sudo rm /root/bin/git"
+  echo
+  echo "You might have to restart your login session after doing that."
   exit 1
 fi
 


### PR DESCRIPTION
Some users run into issues with the git wrapper preventing usage as root when trying to install third party software on OctoPi that for some reason requires to run git as root. See comments to #114 and #373.

This adds a small message to the output generated by the wrapper script to explain to people how to remove the wrapper in order to allow for that kind of usage of git.