### PR TITLE
Modify haproxy.cfg to listen on both IPv4 and IPv6

### DIFF
--- a/src/filesystem/root/etc/haproxy/haproxy.cfg
+++ b/src/filesystem/root/etc/haproxy/haproxy.cfg
@@ -19,8 +19,8 @@ defaults
         timeout server  15min
 
 frontend public
-        bind *:80
-        bind 0.0.0.0:443 ssl crt /etc/ssl/snakeoil.pem
+        bind :::80 v4v6
+        bind :::443 v4v6 ssl crt /etc/ssl/snakeoil.pem
         option forwardfor except 127.0.0.1
         use_backend webcam if { path_beg /webcam/ }
         default_backend octoprint


### PR DESCRIPTION
As requested in #383.

According to [the docs for bind](http://cbonte.github.io/haproxy-dconv/configuration-1.6.html#4.2-bind), `*` and `0.0.0.0` are both IPv4-specific. The equivalent in v6-land is `::`, used here.

The `v4v6` option tells haproxy to bind on both v4 and v6.

I've tested this config on my existing OctoPi installation, which is based on a nightly from a few weeks ago, and OctoPi is responding happily on all v4/v6/http/https. Admittedly, I have not rebuilt a new SD card image and tested that.