### PR TITLE
Add missing shebang

### DIFF
--- a/src/build_dist
+++ b/src/build_dist
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export DIST_PATH=${DIR}


### PR DESCRIPTION
The script is flagged executable, but due to the missing shebang, only an error message is produced:

```
OctoPi/src (devel)> ./build_dist 
Failed to execute process './build_dist'. Reason:
exec: Exec format error
The file './build_dist' is marked as an executable but could not be run by the operating system.
```