### PR TITLE
Add GEMBIRD webcam to list of brokenfps_usb_devices

### DIFF
--- a/src/modules/octopi/filesystem/home/root/bin/webcamd
+++ b/src/modules/octopi/filesystem/home/root/bin/webcamd
@@ -27,7 +27,7 @@ if [ -e "/boot/octopi.txt" ]; then
     source "/boot/octopi.txt"
 fi
 
-brokenfps_usb_devices=("046d:082b" "${additional_brokenfps_usb_devices[@]}")
+brokenfps_usb_devices=("046d:082b" "1908:2310" "${additional_brokenfps_usb_devices[@]}")
 
 # cleans up when the script receives a SIGINT or SIGTERM
 function cleanup() {


### PR DESCRIPTION
The GEMBIRD webcam is brokenfps.  Adding the webcam's usb id to the list allows the webcam to work.

Here's the device's USB:

    Bus 001 Device 005: ID 1908:2310 GEMBIRD 

This is the camera:

https://ae01.alicdn.com/kf/HTB1OlilPpXXXXbWaXXXq6xXFXXXW/Newest-Webcam-USB-12-Megapixel-High-Definition-Camera-Web-Cam-360-Degree-MIC-Clip-on-For.jpg

Here's where I bought it: https://www.aliexpress.com/store/product/FW1S-USB-2-0-Webcam-12-0-Mega-Pixel-HD-Camera-Webcam-360-Degree-MIC-Clip/1283494_32659656232.html