### PR TITLE
Add "redirect" for octopi-network.txt

### DIFF
--- a/src/modules/octopi/filesystem/boot/octopi-network.txt
+++ b/src/modules/octopi/filesystem/boot/octopi-network.txt
@@ -1,0 +1,3 @@
+# Using this file to configure your network connection is no longer supported.
+#
+# Please use octopi-wpa-supplicant.txt instead.


### PR DESCRIPTION
If a user follows some outdated docs after the release of 0.15,
we still want them to find something that helps them get things
running.

Complements https://github.com/guysoft/CustomPiOS/pull/19