### PR TITLE
Install OctoPrint from network via pip

### DIFF
--- a/src/modules/octopi/config
+++ b/src/modules/octopi/config
@@ -27,3 +27,5 @@
 # WiringPi
 [ -n "$OCTOPI_INCLUDE_WIRINGPI" ] || OCTOPI_INCLUDE_WIRINGPI=yes
 
+# yq
+[ -n "$OCTOPI_YQ_DOWNLOAD" ] || OCTOPI_YQ_DOWNLOAD=$(curl -s https://api.github.com/repos/mikefarah/yq/releases/latest | grep "browser_download_url" | grep "yq_linux_arm" | cut -d : -f 2,3 | tr -d \" | tr -d ,)

--- a/src/modules/octopi/config
+++ b/src/modules/octopi/config
@@ -1,11 +1,13 @@
 ###############################################################################
 # All our config settings must start with OCTOPI_
 
-# OctoPrint repo & branch
+# OctoPrint archive
+[ -n "$OCTOPI_OCTOPRINT_ARCHIVE" ] || OCTOPI_OCTOPRINT_ARCHIVE=$(curl -s https://api.github.com/repos/foosel/OctoPrint/releases/latest | grep "zipball_url" | cut -d : -f 2,3 | tr -d \" | tr -d ,)
 [ -n "$OCTOPI_OCTOPRINT_REPO_SHIP" ] || OCTOPI_OCTOPRINT_REPO_SHIP=https://github.com/foosel/OctoPrint.git
-[ -n "$OCTOPI_OCTOPRINT_REPO_BUILD" ] || OCTOPI_OCTOPRINT_REPO_BUILD=
-[ -n "$OCTOPI_OCTOPRINT_REPO_BRANCH" ] || OCTOPI_OCTOPRINT_REPO_BRANCH=master
 [ -n "$OCTOPI_INCLUDE_OCTOPRINT" ] || OCTOPI_INCLUDE_OCTOPRINT=yes
+
+# PyBonjour archive
+[ -n "$OCTOPI_PYBONJOUR_ARCHIVE" ] || OCTOPI_PYBONJOUR_ARCHIVE=https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/pybonjour/pybonjour-1.1.1.tar.gz
 
 # CuraEngine archive & version
 [ -n "$OCTOPI_CURAENGINE_VERSION" ] || OCTOPI_CURAENGINE_VERSION=15.04.6

--- a/src/modules/octopi/filesystem/home/pi/.octoprint/config.yaml
+++ b/src/modules/octopi/filesystem/home/pi/.octoprint/config.yaml
@@ -7,10 +7,6 @@ plugins:
     cura_engine: /usr/local/bin/cura_engine
   discovery:
     publicPort: 80
-  softwareupdate:
-    checks:
-      octoprint:
-        update_folder: /home/pi/OctoPrint
 server:
   commands:
     systemShutdownCommand: sudo shutdown -h now

--- a/src/modules/octopi/filesystem/home/pi/OctoPrint/README.txt
+++ b/src/modules/octopi/filesystem/home/pi/OctoPrint/README.txt
@@ -1,0 +1,7 @@
+OctoPrint 1.3.6 and newer no longer rely on a git checkout for updates,
+so OctoPi no longer goes that route either.
+
+Feel free to manually create a git clone though if you need it (e.g. for
+branch based updates or on board development):
+
+    ~/scripts/add-octoprint-checkout

--- a/src/modules/octopi/filesystem/home/pi/scripts/add-octoprint-checkout
+++ b/src/modules/octopi/filesystem/home/pi/scripts/add-octoprint-checkout
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+OCTOPRINT_FOLDER=/home/pi/OctoPrint
+OCTOPRINT_CONFIG=/home/pi/.octoprint/config.yaml
+
+pause() {
+  read -n1 -r -p $'Press any key to continue or Ctrl+C to exit...\n' key
+}
+
+echo
+echo "This will add a git checkout of OctoPrint to ~/OctoPrint."
+echo
+echo "This can be helpful if you want to run development branches"
+echo "of OctoPrint or do local development yourself."
+echo
+echo "It is however not needed for OctoPrint's normal operation."
+echo
+echo "If you do not want to add the git checkout after all, please"
+echo "hit Ctrl+C now."
+echo
+
+pause
+
+echo "--- Adding git checkout"
+
+rm -r $OCTOPRINT_FOLDER || true
+git clone https://github.com/foosel/OctoPrint.git $OCTOPRINT_FOLDER
+
+echo "--- Configuring checkout folder in OctoPrint's config.yaml"
+
+echo "plugins: {softwareupdate: {checks: {octoprint: {update_folder: $OCTOPRINT_FOLDER}}}}" | yq m -i $OCTOPRINT_CONFIG -
+
+echo
+echo "--- Done!"
+echo
+
+echo "Your git checkout is now available at ~/OctoPrint. Please note that it"
+echo "is currently not installed. If you want to replace the default installation"
+echo "of OctoPrint with whatever is currently checked out in your git checkout"
+echo "you'll need to do this manually. You'll also need to keep your checkout"
+echo "up to date manually if you still have OctoPrint's update mode set to release"
+echo "tracking."
+echo

--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -48,20 +48,6 @@ pushd /home/pi
 
     #OctoPrint
     PIP_DEFAULT_TIMEOUT=60 sudo -u pi /home/pi/oprint/bin/pip install $OCTOPI_OCTOPRINT_ARCHIVE
-
-    #"redirect" for people still expecting a source checkout at ~/OctoPrint...
-    sudo -u pi mkdir OctoPrint
-    cat <<EOT >> OctoPrint/README.txt
-OctoPrint 1.3.6 and newer no longer rely on a git checkout for updates,
-so OctoPi no longer goes that route either.
-
-Feel free to manually create a git clone though if you need it (e.g. for
-branch based updates or on board development):
-
-    cd ~
-    rm -r OctoPrint
-    git clone $OCTOPI_OCTOPRINT_REPO_SHIP
-EOT
   fi
 
   #mjpg-streamer
@@ -128,6 +114,9 @@ EOT
     echo "--- Installing WiringPi"
     apt-get install wiringpi
   fi
+
+  # fetch current yq build and install to /usr/local/bin
+  wget -O yq $OCTOPI_YQ_DOWNLOAD && chmod +x yq && mv yq /usr/local/bin
   
 popd
 

--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -44,13 +44,24 @@ pushd /home/pi
     echo "--- Installing OctoPrint"
 
     #pybonjour (for mdns discovery)
-    sudo -u pi /home/pi/oprint/bin/pip install https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/pybonjour/pybonjour-1.1.1.tar.gz
+    sudo -u pi /home/pi/oprint/bin/pip install $OCTOPI_PYBONJOUR_ARCHIVE
 
     #OctoPrint
-    gitclone OCTOPI_OCTOPRINT_REPO OctoPrint
-    pushd OctoPrint
-      PIP_DEFAULT_TIMEOUT=60 sudo -u pi /home/pi/oprint/bin/python setup.py install
-    popd
+    PIP_DEFAULT_TIMEOUT=60 sudo -u pi /home/pi/oprint/bin/pip install $OCTOPI_OCTOPRINT_ARCHIVE
+
+    #"redirect" for people still expecting a source checkout at ~/OctoPrint...
+    sudo -u pi mkdir OctoPrint
+    cat <<EOT >> OctoPrint/README.txt
+OctoPrint 1.3.6 and newer no longer rely on a git checkout for updates,
+so OctoPi no longer goes that route either.
+
+Feel free to manually create a git clone though if you need it (e.g. for
+branch based updates or on board development):
+
+    cd ~
+    rm -r OctoPrint
+    git clone $OCTOPI_OCTOPRINT_REPO_SHIP
+EOT
   fi
 
   #mjpg-streamer


### PR DESCRIPTION
OctoPrint 1.3.6+ no longer relies on git for updating itself,
so there's really no use to ship with a full blown git checkout
any more.

In case people miss that however, there's a README.txt in place
that tells people how to get it back if they do need it.