### PR TITLE
Back to MAJOR.MINOR.PATCH version scheme

### DIFF
--- a/src/config
+++ b/src/config
@@ -1,4 +1,4 @@
 export DIST_NAME=OctoPi
-export DIST_VERSION=0.15
+export DIST_VERSION=0.15.0
 export MODULES="base(raspicam, network, disable-services(octopi), password-for-sudo)"
 


### PR DESCRIPTION
We so far followed MAJOR.MINOR.PATCH as version scheme. I suggest we stay there to not confuse people ("why does 0.15 follow 0.14.0?").