### PR TITLE
Fixed white space to fix setting the video_device_count variable

### DIFF
--- a/src/modules/octopi/filesystem/home/root/bin/webcamd
+++ b/src/modules/octopi/filesystem/home/root/bin/webcamd
@@ -121,7 +121,7 @@ vcgencmd version > /dev/null 2>&1
 # keep mjpg streamer running if some camera is attached
 while true; do
     # get number of usb video devices
-    video_device_count = $(ls /dev/video? 2> /dev/null | wc -l)
+    video_device_count=$(ls /dev/video? 2> /dev/null | wc -l)
     if [ "$video_device_count" != "0" ] && { [ "$camera" = "auto" ] || [ "$camera" = "usb" ] ; }; then
         startUsb
         sleep 30 &


### PR DESCRIPTION
So sorry, I forgot bash is strict about white space when setting a variable. Fixed, and tested on real OctoPi.