### PR TITLE
Support for other webcams than /dev/video0, fixed a regular expression

### DIFF
--- a/src/modules/octopi/filesystem/home/root/bin/webcamd
+++ b/src/modules/octopi/filesystem/home/root/bin/webcamd
@@ -29,6 +29,14 @@ fi
 
 brokenfps_usb_devices=("046d:082b" "1908:2310" "${additional_brokenfps_usb_devices[@]}")
 
+# check if array contains a string
+function containsString() {
+  local e match="$1"
+  shift
+  for e; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
+}
+
 # cleans up when the script receives a SIGINT or SIGTERM
 function cleanup() {
     # make sure that all child processed die when we die
@@ -63,7 +71,7 @@ function startRaspi {
 
 # starts up the USB webcam
 function startUsb {
-    options="$camera_usb_options"
+    options="$usb_options"
     device="video0"
 
     # check for parameter and set the device if it is given as a parameter
@@ -72,16 +80,8 @@ function startUsb {
         device=`basename "$input"`
     fi
 
-    # override the device if it is set in the config
-    extracted_device=`echo $options | sed 's@.*-d /dev/\(video[0-9]\+\).*@\1@'`
-    if [ "$extracted_device" != "$options" ]
-    then
-        # the camera options refer to a device, use that for determining product
-        device=$extracted_device
-    else
-        # there was no device explicitly set in the options, let's add it there
-        options="$options -d /dev/$device"
-    fi
+    # add video device into options
+    options="$options -d /dev/$device"
 
     uevent_file="/sys/class/video4linux/$device/device/uevent"
     if [ -e $uevent_file ]; then
@@ -128,22 +128,59 @@ echo ""
 # I have no idea why, but that's how it is...
 vcgencmd version > /dev/null 2>&1
 
+usb_options="$camera_usb_options"
+
+# if webcam device is explicitly given in /boot/octopi.txt, save the path of the device
+# to a variable and remove its parameter from usb_options
+extracted_device=`echo $usb_options | sed 's@.*-d \(/dev/video[0-9]\+\).*@\1@'`
+if [ "$extracted_device" != "$usb_options" ]
+then
+    # the camera options refer to a device, save it in a variable
+    usb_device_path="$extracted_device"
+    # replace video device parameter with empty string and strip extra whitespace
+    usb_options=`echo $usb_options | sed 's/\-d \/dev\/video[0-9]\+//g' | awk '$1=$1'`
+    echo "Explicitly set USB device was found in options: $usb_device_path"
+fi
+
 # keep mjpg streamer running if some camera is attached
 while true; do
+
     # get list of usb video devices into an array
-    video_devices=($(ls /dev/video? 2> /dev/null))
+    video_devices=($(find /dev -regextype sed -regex '\/dev/video[0-9]\+' | sort 2> /dev/null))
+    echo "Found video devices:" && printf '%s\n' "${video_devices[@]}"
+
     if [ ${#video_devices[@]} != 0 ] && { [ "$camera" = "auto" ] || [ "$camera" = "usb" ] ; }; then
-        #start with first usb camera as the parameter
-        startUsb "${video_devices[0]}"
+
+        if [[ $usb_device_path ]]; then
+            # usb device is explicitly set in options
+            if containsString "$usb_device_path" "${video_devices[@]}"; then
+                # explicitly set usb device was found in video_devices array, start usb with the found device
+                echo "USB device was set in options and found in devices, start MJPG-streamer with the configured USB video device: $usb_device_path"
+                startUsb "$usb_device_path"
+            else
+                # explicitly set usb device was not found
+                echo "Configured USB camera was not detected, trying again in two minutes"
+                sleep 120 &
+                wait
+            fi
+        else
+            # device is not set explicitly in options, start usb with first found usb camera as the device
+            echo "USB device was not set in options, start MJPG-streamer with the first found video device: ${video_devices[0]}"
+            startUsb "${video_devices[0]}"
+        fi
+
         sleep 30 &
         wait
+
     elif [ "`vcgencmd get_camera`" = "supported=1 detected=1" ] && { [ "$camera" = "auto" ] || [ "$camera" = "raspi" ] ; }; then
         startRaspi
         sleep 30 &
         wait
+
     else
         echo "No camera detected, trying again in two minutes"
         sleep 120 &
         wait
+
     fi
 done

--- a/src/modules/octopi/filesystem/home/root/bin/webcamd
+++ b/src/modules/octopi/filesystem/home/root/bin/webcamd
@@ -66,11 +66,21 @@ function startUsb {
     options="$camera_usb_options"
     device="video0"
 
-    extracted_device=`echo $options | sed 's@.*-d /dev/\(video[0-9]+\).*@\1@'`
+    # check for parameter and set the device if it is given as a parameter
+    input=$1
+    if [[ -n $input ]]; then
+        device=`basename "$input"`
+    fi
+
+    # override the device if it is set in the config
+    extracted_device=`echo $options | sed 's@.*-d /dev/\(video[0-9]\+\).*@\1@'`
     if [ "$extracted_device" != "$options" ]
     then
-        # the camera options refer to another device, use that for determining product
+        # the camera options refer to a device, use that for determining product
         device=$extracted_device
+    else
+        # there was no device explicitly set in the options, let's add it there
+        options="$options -d /dev/$device"
     fi
 
     uevent_file="/sys/class/video4linux/$device/device/uevent"
@@ -120,10 +130,11 @@ vcgencmd version > /dev/null 2>&1
 
 # keep mjpg streamer running if some camera is attached
 while true; do
-    # get number of usb video devices
-    video_device_count=$(ls /dev/video? 2> /dev/null | wc -l)
-    if [ "$video_device_count" != "0" ] && { [ "$camera" = "auto" ] || [ "$camera" = "usb" ] ; }; then
-        startUsb
+    # get list of usb video devices into an array
+    video_devices=($(ls /dev/video? 2> /dev/null))
+    if [ ${#video_devices[@]} != 0 ] && { [ "$camera" = "auto" ] || [ "$camera" = "usb" ] ; }; then
+        #start with first usb camera as the parameter
+        startUsb "${video_devices[0]}"
         sleep 30 &
         wait
     elif [ "`vcgencmd get_camera`" = "supported=1 detected=1" ] && { [ "$camera" = "auto" ] || [ "$camera" = "raspi" ] ; }; then

--- a/src/modules/octopi/filesystem/home/root/bin/webcamd
+++ b/src/modules/octopi/filesystem/home/root/bin/webcamd
@@ -147,9 +147,11 @@ while true; do
 
     # get list of usb video devices into an array
     video_devices=($(find /dev -regextype sed -regex '\/dev/video[0-9]\+' | sort 2> /dev/null))
-    echo "Found video devices:" && printf '%s\n' "${video_devices[@]}"
 
     if [ ${#video_devices[@]} != 0 ] && { [ "$camera" = "auto" ] || [ "$camera" = "usb" ] ; }; then
+
+        echo "Found video devices:"
+        printf '%s\n' "${video_devices[@]}"
 
         if [[ $usb_device_path ]]; then
             # usb device is explicitly set in options


### PR DESCRIPTION
This patch tries to allow detection of usb webcams. It also corrects a small regular expression problem.
* When polling for webcams, we check for cameras by listing all video devices, and if at least one is found, we give the path of the first device to startUsb function. 
* StartUsb will use the device given as the parameter. It also has an option override the first found device which is pssed as a parameter, if it's explicitly set in the /boot/octopi.txt.
* If the device is not given it the octopi.txt, we will add the device path as a parameter for mjpeg-streamer, into the options variable.
* The unescaped "+" sign that was used in the regular expression with sed, to get data for the extracted_device variable, is now also correctly escaped, and the expression works now on OctoPi.
* The uevent check will now also use the correct device identifier, because the regular expression now parses the device set in octopi.txt correctly.

Tests:
* I have tested the device override; the /boot/octopi.txt will override the automatically detected devices. The device in octopi.txt is passed to mjpeg-streamer & uevent check correctly.
* I have tested that when plugging many usb video devices and unplugging them so that the device id changes, the script will now find /dev/video1 by itself and spawn mjpeg-streamer with that device correctly (when the explicit device is not given in /boot/octopi.txt)
* Boots fine and the stream gets up after boot
* Regular expression fix: (used in /boot/octopi.txt device override / extracted_device)

Incorrect behaviour, before the fix:

```
  pi@octopi:~ $ echo `echo "-r 1920x1080 -d /dev/video32 -e -t pal" | sed 's@.*-d /dev/\(video[0-9]+\).*@\1@'`
  -r 1920x1080 -d /dev/video32 -e -t pal
  pi@octopi:~ $ echo `echo "-r 1920x1080 -d /dev/video0 -e -t pal" | sed 's@.*-d /dev/\(video[0-9]+\).*@\1@'`
  -r 1920x1080 -d /dev/video0 -e -t pal
```

Correct behaviour on the Raspberry Pi after the fix:

```
  pi@octopi:~ $ echo `echo "-r 1920x1080 -d /dev/video3 -e -t pal" | sed 's@.*-d /dev/\(video[0-9]\+\).*@\1@'`
  video3
  pi@octopi:~ $ echo `echo "-r 1920x1080 -d /dev/video32 -e -t pal" | sed 's@.*-d /dev/\(video[0-9]\+\).*@\1@'`
  video32
```
