### PR TITLE
Add Genius WideCam F100 to brokenfps

### DIFF
--- a/src/modules/octopi/filesystem/home/root/bin/webcamd
+++ b/src/modules/octopi/filesystem/home/root/bin/webcamd
@@ -27,7 +27,7 @@ if [ -e "/boot/octopi.txt" ]; then
     source "/boot/octopi.txt"
 fi
 
-brokenfps_usb_devices=("046d:082b" "1908:2310" "${additional_brokenfps_usb_devices[@]}")
+brokenfps_usb_devices=("046d:082b" "1908:2310" "0458:708c" "${additional_brokenfps_usb_devices[@]}")
 
 # cleans up when the script receives a SIGINT or SIGTERM
 function cleanup() {


### PR DESCRIPTION
Genius WideCam F100 is a popular webcam for 3D-printers because of it's very wide FOV @ 120 deg.
It only supports one specific frame rate per resolution so disabling the frame rate option is the best option.
This will also fix #365 so that can be closed.