### PR TITLE
Fix definition of some broken webcams

### DIFF
--- a/src/modules/octopi/filesystem/boot/octopi.txt
+++ b/src/modules/octopi/filesystem/boot/octopi.txt
@@ -36,16 +36,21 @@
 #
 # By default, this is done for the following devices:
 #   Logitech C170 (046d:082b)
+#   GEMBIRD (1908:2310)
+#   Genius F100 (0458:708c)
+#   Cubeternet GL-UPC822 UVC WebCam (1e4e:0102)
 #
 # Using the following option it is possible to add additional devices. If
 # your webcam happens to show above symptoms, try determining your cam's
 # vendor and product id via lsusb, activating the line below by removing # and 
-# adding it as shown examplatory.
+# adding it, e.g. for two broken cameras "aabb:ccdd" and "aabb:eeff"
+#
+#   additional_brokenfps_usb_devices=("aabb:ccdd" "aabb:eeff")
 #
 # If this fixes your problem, please report it back so we can include the device
-# out of the box.
+# out of the box: https://github.com/guysoft/OctoPi/issues
 #
-#additional_brokenfps_usb_devices=("046d:082b" "1908:2310" "1e4e:0102" "aabb:ccdd")
+#additional_brokenfps_usb_devices=()
 
 ### Additional options to supply to MJPG Streamer for the RasPi Cam
 #

--- a/src/modules/octopi/filesystem/home/root/bin/webcamd
+++ b/src/modules/octopi/filesystem/home/root/bin/webcamd
@@ -27,7 +27,7 @@ if [ -e "/boot/octopi.txt" ]; then
     source "/boot/octopi.txt"
 fi
 
-brokenfps_usb_devices=("046d:082b" "1908:2310" "0458:708c" "${additional_brokenfps_usb_devices[@]}")
+brokenfps_usb_devices=("046d:082b" "1908:2310" "0458:708c" "1e4e:0102" "${additional_brokenfps_usb_devices[@]}")
 
 # check if array contains a string
 function containsString() {


### PR DESCRIPTION
They were only added to the (by default commented out) config line
in octopi.txt but missing in webcamd. Also the defaults weren't
properly documented.