### PR TITLE
Put IPv6 addressess in brackets

### DIFF
--- a/src/modules/octopi/filesystem/home/pi/scripts/welcome
+++ b/src/modules/octopi/filesystem/home/pi/scripts/welcome
@@ -16,7 +16,12 @@ do
 done
 for ip in $_IP;
 do
-    echo "    http://$ip"
+     if [[ $ip =~ .*:.* ]]
+     then
+         echo "    http://[$ip]"
+     else
+        echo "    http://$ip"
+     fi
 done
 
 echo

--- a/src/modules/octopi/filesystem/home/pi/scripts/welcome
+++ b/src/modules/octopi/filesystem/home/pi/scripts/welcome
@@ -16,12 +16,12 @@ do
 done
 for ip in $_IP;
 do
-     if [[ $ip =~ .*:.* ]]
-     then
-         echo "    http://[$ip]"
-     else
+    if [[ $ip =~ .*:.* ]]
+    then
+        echo "    http://[$ip]"
+    else
         echo "    http://$ip"
-     fi
+    fi
 done
 
 echo


### PR DESCRIPTION
Brackets to be RFC2732 compliant
>To use a literal IPv6 address in a URL, the literal address should be enclosed in "[" and "]" characters.

It worked, (but the KDE console doesn't recognize it correctly as a link, without this fix firefox would complain and try it as a search)