### PR TITLE
Directly exec git instead of running child process

### DIFF
--- a/src/modules/octopi/filesystem/home/root/bin/git
+++ b/src/modules/octopi/filesystem/home/root/bin/git
@@ -13,4 +13,4 @@ then
   exit 1
 fi
 
-/usr/bin/git "$@"
+exec /usr/bin/git "$@"


### PR DESCRIPTION
Admittedly, this is a microoptimization, but we might as well run git with `exec` in the wrapper script. In the current incarnation bash stays open & takes a bit of extra memory but if we `exec` directly bash is completely replaced with the git process.