### PR TITLE
Added safemode script to toggle on Safe Mode once

### DIFF
--- a/src/modules/octopi/filesystem/home/pi/scripts/safemode
+++ b/src/modules/octopi/filesystem/home/pi/scripts/safemode
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if grep -q "startOnceInSafeMode" ~/.octoprint/config.yaml;
+then
+	# If found,replace the existing line
+	sed -i 's/.*startOnceInSafeMode: false.*/\ \ startOnceInSafeMode: true/' ~/.octoprint/config.yaml
+else
+	# Append otherwise
+	sed -i '/server:/a \ \ startOnceInSafeMode: true' ~/.octoprint/config.yaml
+fi


### PR DESCRIPTION
You would think that a set of simple instructions on how to set Safe Mode would be sufficient for most users. But again today, I find myself [teaching someone](https://community.octoprint.org/t/server-not-startet) basic Linux commands on the forum.

I've just created a script which in theory will add the Safe Mode toggle in what I hope to be a safe method of doing so. You might consider either putting this in the `pi` user's path or add a symlink to accomplish this so that we don't have to educate them on how to call the script by location.