### PR TITLE
Add workaround for a bug in Raspberry Pi 4 VL805 0x000137ab firmware (streaming issues)

### DIFF
--- a/src/modules/octopi/filesystem/home/root/bin/webcamd
+++ b/src/modules/octopi/filesystem/home/root/bin/webcamd
@@ -115,6 +115,37 @@ function goodbye() {
 # runs MJPG Streamer, using the provided input plugin + configuration
 function runMjpgStreamer {
     input=$1
+
+    # There are problems with 0x000137ab firmware on VL805 (Raspberry Pi 4}).
+    # Try to autodetect offending firmware and temporarily fix the issue
+    # by changing power management mode
+    echo "Checking for VL805 (Raspberry Pi 4)..."
+    if [[ -f /usr/bin/vl805 ]]; then
+        VL805_VERSION=$(/usr/bin/vl805)
+        VL805_VERSION=${VL805_VERSION#*: }
+        echo " - version 0x${VL805_VERSION} detected"
+        case "$VL805_VERSION" in
+            00013701)
+                echo "    - nothing to be done. It shouldn't cause USB problems."
+                ;;
+            000137ab)
+                echo -e "    - \e[31mThis version is known to cause problems with USB cameras.\e[39m"
+                echo -e "      You may want to downgrade to 0x0013701."
+                echo -e "    - [FIXING] Trying the setpci -s 01:00.0 0xD4.B=0x41 hack to mitigate the"
+                echo -e "      issue. It disables ASPM L1 on the VL805. Your board may (or may not) get"
+                echo -e "      slightly hotter. For details see:"
+                echo -e "      https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=244421"
+                setpci -s 01:00.0 0xD4.B=0x41
+                ;;
+            *)
+                echo "   - unknown firmware version. Doing nothing."
+                ;;
+        esac
+    else
+        echo "  - It seems that you don't have VL805 (Raspberry Pi 4)."
+        echo "    There should be no problems with USB (a.k.a. select() timeout)"
+    fi
+
     pushd $MJPGSTREAMER_HOME > /dev/null 2>&1
         echo Running ./mjpg_streamer -o "output_http.so -w $camera_http_webroot $camera_http_options" -i "$input"
         LD_LIBRARY_PATH=. ./mjpg_streamer -o "output_http.so -w $camera_http_webroot $camera_http_options" -i "$input" &


### PR DESCRIPTION
The `0x000137ab` frimware of `VL805` on Raspberry Pi 4 is known to cause problems with USB cameras - stream not working or working only in very low resolution (like QVGA `320x240`). See #621.

Choosing slightly higher resolution `640x480` causes streaming to fail: you can see a lot of `uvcvideo: USB isochronous frame lost (-18).` lines in the dmesg logs and `i: select() timeout` in the `mjpg_streamer`'s output.

You may need to enable uvcvideo's tracing to see those errors:
``` bash
  echo 0xffff > /sys/module/uvcvideo/parameters/trace
```

For details see: https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=244421