### PR TITLE
fix/enable haproxy logging

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/haproxy/haproxy.cfg
+++ b/src/modules/octopi/filesystem/root/etc/haproxy/haproxy.cfg
@@ -2,7 +2,7 @@ global
         maxconn 4096
         user haproxy
         group haproxy
-        log 127.0.0.1 local1 debug
+        log /dev/log local1 debug
 
 defaults
         log     global


### PR DESCRIPTION
The config sends logs to rsyslog localhost, which isn't listening (even on
localhost). Thankfully the chroot mapping is already set up, so simply
sending it to /dev/log works fine.

Tested locally. Found while trying to test for #639 vulnerabilities.