### PR TITLE
enable compression at haproxy layer

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/haproxy/haproxy.cfg
+++ b/src/modules/octopi/filesystem/root/etc/haproxy/haproxy.cfg
@@ -7,6 +7,7 @@ global
 defaults
         log     global
         mode    http
+        compression algo gzip
         option  httplog
         option  dontlognull
         retries 3


### PR DESCRIPTION
This spins out of a discussion at [OctoPrint#3529](https://github.com/OctoPrint/OctoPrint/issues/3529), where @flaviut did the math on how enabling http compression is really helpful, even on a little Pi. It'd be nice if we could get it enabled in Tornado, but this is easier and won't be invalidated by work on Tornado if that gets done.

haproxy attempts to compress every mime type, and it is a big win. You can go over to the other issue to see the comparisons. It doesn't seem to support setting a compression level, and [it is cautious](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#compression), so it should be fine.

Tested locally.