### PR TITLE
Delete OctoPrint logfiles configured via pattern and age

### DIFF
--- a/src/modules/octopi/config
+++ b/src/modules/octopi/config
@@ -34,3 +34,7 @@
 [ -n "$OCTOPI_YQ_DOWNLOAD" ] || OCTOPI_YQ_DOWNLOAD=$(wget -q -O - https://api.github.com/repos/mikefarah/yq/releases/latest | grep "browser_download_url" | grep "yq_linux_arm" | cut -d : -f 2,3 | tr -d \" | tr -d ,)
 
 [ -n "$OCTOPI_COMMIT" ] || OCTOPI_COMMIT=`pushd "${DIST_PATH}" > /dev/null ; git rev-parse HEAD ; popd > /dev/null`
+
+# delete old logfiles 
+[ -n "$OCTOPI_LOG_CLEAN_PATTERNS" ] || OCTOPI_LOG_CLEAN_PATTERNS='serial.log.*'
+[ -n "$OCTOPI_LOG_CLEAN_DAYS" ] || OCTOPI_LOG_CLEAN_DAYS=14

--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -142,6 +142,12 @@ EOT
   # fetch current yq build and install to /usr/local/bin
   wget -O yq $OCTOPI_YQ_DOWNLOAD && chmod +x yq && mv yq /usr/local/bin
   
+  if [ -n "$OCTOPI_LOG_CLEAN_PATTERNS" -a -n "$OCTOPI_LOG_CLEAN_DAYS" ]; then
+    cmd="find \$HOME/.octoprint/logs -mtime +$OCTOPI_LOG_CLEAN_DAYS \\( "
+    names="$(and=; printf '%s\n' "$OCTOPI_LOG_CLEAN_PATTERNS" | tr ' ' '\n' | while read -r p; do [ -n "$p" ] || continue; printf "%s-name '%s'" "$and" "$p"; and=" -a "; done)"
+    cmd="$cmd$names \) -delete"
+    printf '@reboot %s\n@daily %s\n' "$cmd" "$cmd" | sudo -u pi crontab
+  fi
 popd
 
 #Make sure user pi has access to serial ports


### PR DESCRIPTION
I always have serial.log enabled. These use by large the most space in .octoprint/logs therefore I have created a crontab to delete old logfiles. There are two crontab entries created, one for boot and one daily. The boot entry is meant for users who are shutting their Raspi down between prints.

The pattern(s) (blank separated) and the age are configured via src/modules/octopi/config.