### PR TITLE
added default listener to localhost for webcamd

### DIFF
--- a/src/modules/octopi/filesystem/home/root/bin/webcamd
+++ b/src/modules/octopi/filesystem/home/root/bin/webcamd
@@ -46,7 +46,7 @@ for cfg_file in ${cfg_files[@]}; do
   camera_usb_options="-r 640x480 -f 10"
   camera_raspi_options="-fps 10"
   camera_http_webroot="./www-octopi"
-  camera_http_options="-n"
+  camera_http_options="-n --listen 127.0.0.1"
   additional_brokenfps_usb_devices=()
 
   if [[ -e ${cfg_file} ]]; then


### PR DESCRIPTION
Noticed webcamd was accessible on all interfaces on port 8080. Fixed to only be accessible to 127.0.0.1 (localhost). 