### PR TITLE
Remove pybonjour dependency install

### DIFF
--- a/src/modules/octopi/config
+++ b/src/modules/octopi/config
@@ -6,9 +6,6 @@
 [ -n "$OCTOPI_OCTOPRINT_REPO_SHIP" ] || OCTOPI_OCTOPRINT_REPO_SHIP=https://github.com/foosel/OctoPrint.git
 [ -n "$OCTOPI_INCLUDE_OCTOPRINT" ] || OCTOPI_INCLUDE_OCTOPRINT=yes
 
-# PyBonjour archive
-[ -n "$OCTOPI_PYBONJOUR_ARCHIVE" ] || OCTOPI_PYBONJOUR_ARCHIVE=https://github.com/OctoPrint/pybonjour-python3/archive/master.zip
-
 # CuraEngine archive & version
 [ -n "$OCTOPI_CURAENGINE_VERSION" ] || OCTOPI_CURAENGINE_VERSION=15.04.6
 [ -n "$OCTOPI_CURAENGINE_ARCHIVE" ] || OCTOPI_CURAENGINE_ARCHIVE=https://github.com/Ultimaker/CuraEngine/archive/$OCTOPI_CURAENGINE_VERSION.zip
@@ -37,3 +34,4 @@
 
 # Fixed apt mirror
 [ -n "$OCTOPI_APTMIRROR" ] || OCTOPI_APTMIRROR=
+

--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -44,15 +44,10 @@ pushd /home/pi
   sudo -u pi python3 -m virtualenv --python=python3 oprint
   sudo -u pi /home/pi/oprint/bin/pip install --upgrade pip
 
-  # OctoPrint & pyserial
+  # OctoPrint
   if [ "$OCTOPI_INCLUDE_OCTOPRINT" == "yes" ]
   then
     echo "--- Installing OctoPrint"
-
-    #pybonjour (for mdns discovery)
-    sudo -u pi /home/pi/oprint/bin/pip install $OCTOPI_PYBONJOUR_ARCHIVE
-
-    #OctoPrint
     PIP_DEFAULT_TIMEOUT=60 sudo -u pi /home/pi/oprint/bin/pip install $OCTOPI_OCTOPRINT_ARCHIVE
   fi
 


### PR DESCRIPTION
OctoPrint no longer depends on it (it's no longer maintained and
also not compatible to Python 3) and instead now uses zeroconf.

As it's incompatible to Python 3 anyhow, installing it no longer
makes sense.