### PR TITLE
Redirect to SSL if not enabled

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/haproxy/haproxy.cfg
+++ b/src/modules/octopi/filesystem/root/etc/haproxy/haproxy.cfg
@@ -22,6 +22,7 @@ defaults
 frontend public
         bind :::80 v4v6
         bind :::443 v4v6 ssl crt /etc/ssl/snakeoil.pem
+        http-request redirect scheme https if !{ ssl_fc }
         option forwardfor except 127.0.0.1
         use_backend webcam if { path_beg /webcam/ }
         use_backend webcam_hls if { path_beg /hls/ }


### PR DESCRIPTION
Since both 80 and 443 are enabled, one should redirect to port 443 if
a request comes in on port 80.