### PR TITLE
Set HAProxy Diffie-Hellman key size to 2048

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/haproxy/haproxy.cfg
+++ b/src/modules/octopi/filesystem/root/etc/haproxy/haproxy.cfg
@@ -3,6 +3,7 @@ global
         user haproxy
         group haproxy
         log /dev/log local1 debug
+        tune.ssl.default-dh-param 2048
 
 defaults
         log     global


### PR DESCRIPTION
Testing the haproxy.cfg file using the version of haproxy installed by OctoPi generates a warning. 

HA-Proxy version on RasPi Buster is
    HA-Proxy version 1.8.19-1+rpi1 2019/03/14

To test the config file by haproxy use the '-c' (check) flag as
   `sudo haproxy -c -f /etc/haproxy/haproxy.cfg`
which generates the warning
```
   [WARNING] 291/152612 (2843) : Setting tune.ssl.default-dh-param to 1024 by default,
   if your workload permits it you should set it to at least 2048.
   Please set a value >= 1024 to make this warning disappear.
```

HA-Proxy Documentation for tune.ssl.default-dh-param feature states 
``` Higher values increase CPU load and may not be supported by some clients (IE:Java 7).```

This only affects SSL traffic. Non-encrypted traffic is unaffected. 

Adding `tune.ssl.default-hd-param XXXX` to haproxy.cfg file gets rid of haproxy
warning message where XXXX can be any positive integer.

Tested with values both at 1024 (default) and 2048 (recommended)

Tested on a RasPi 3B with `ab -n 20 -c 1 ...` and also tested by firefox browser
by refreshing the home page at about 1 request per second. (e.g.  a few people 
impatiently reloading the OctoPrint pages repeatedly). 

Load tests showed no measurable difference in user load (uptime)
between a value of 1024 and the recommend value 2048.

Tests using `ab` showed no measurable difference in response time or failure rate
between 1024 and 2048 (2048 was actually faster, but might have been due to caching).

HA-Proxy recommended value of 2048 does not measurably impact 
performance vs the default of 1024. 