### PR TITLE
Add note about raspi cam options being ignored

### DIFF
--- a/src/modules/octopi/filesystem/boot/octopi.txt
+++ b/src/modules/octopi/filesystem/boot/octopi.txt
@@ -53,7 +53,10 @@
 
 ### Additional options to supply to MJPG Streamer for the RasPi Cam
 #
-# See https://faq.octoprint.org/mjpg-streamer-config for available options
+# See https://faq.octoprint.org/mjpg-streamer-config for available options.
+#
+# NOTE: Newer raspi cam modules are reporting as usb devices causing these
+#       options to be ignored. Set `camera="raspi"` to avoid these issues.
 #
 # Defaults to 10fps
 #


### PR DESCRIPTION
[Myself, and others](https://community.octoprint.org/t/camera-raspi-options-seems-to-be-ignored/24939) have run into the problem of setting options for `camera_raspi_options` only to have them be ignored. It appears that this is due to some pi cam modules being detected as USB cams and not pi cams as described in #674 

Short of rewriting the camera detection code, this PR adds a note in the base `octopi.txt` to help people running into the issue.

The note reads:
```
NOTE: Newer raspi cam modules are reporting as usb devices causing these options to be ignored. Set `camera="raspi"` to avoid these 
```