### PR TITLE
Increase restart time to 1 second

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/systemd/system/webcamd.service
+++ b/src/modules/octopi/filesystem/root/etc/systemd/system/webcamd.service
@@ -9,6 +9,7 @@ StandardError=append:/var/log/webcamd.log
 ExecStart=/root/bin/webcamd
 Restart=always
 Type=forking
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
HI,

thanks for your work ! 

by default, when the service crash, it is restarted within 100 ms. This patch increase the time in order to eventually let the usb device to be ready.
This option is described here : https://www.freedesktop.org/software/systemd/man/systemd.service.html#RestartSec=