### PR TITLE
Add explanation of git wrapper script

### DIFF
--- a/src/modules/octopi/filesystem/home/root/bin/git
+++ b/src/modules/octopi/filesystem/home/root/bin/git
@@ -3,6 +3,8 @@
 if [ "$(id -u)" == "0" ]
 then
   echo "Please do not run git as root, your regular user account is enough :)"
+  echo "The rationale behind this restriction is to prevent cloning the OctoPrint"
+  echo "repository as root, which will most likely break some functionality."
   echo
   echo "If you need to run git with root rights for some other application than"
   echo "what comes preinstalled on this image you can remove this sanity check:"


### PR DESCRIPTION
Hi @guysoft,

I was just trying to install a application which obviously runs git as root on my octopi installation. I stumbled upon the git wrapper and temporary disabled it. But I couldn't figure out why this restriction was added until I looked it up in the issues: #373. I think it would be a good idea to not only tell the user what is happening and how they can resolve it, but also why this is happening. I've added a suggestion, but rather take it as a general idea :)

Best regards,
Ben