### PR TITLE
Add avrdude for firmware flashing

### DIFF
--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -262,6 +262,11 @@ systemctl_if_exists enable ffmpeg_hls.service
 
 systemctl_if_exists enable networkcheck.timer
 
+### Firmare flashing
+
+echo "--- Installing avrdude"
+apt-get -y install avrdude
+
 #cleanup
 apt-get clean
 apt-get autoremove -y


### PR DESCRIPTION
Let's add avrdude for firmware flashing which is needed if done via octoprint and available plugins