### PR TITLE
Fix problem where cmake fails to detect compiler

### DIFF
--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -33,7 +33,7 @@ echo "removing:" $remove_extra
 apt-get remove -y --purge  $remove_extra
 apt-get autoremove -y
 
-apt-get -y --force-yes install python3 python3-virtualenv python3-dev git screen subversion cmake avahi-daemon libavahi-compat-libdnssd1 libffi-dev libssl-dev libatlas3-base
+apt-get -y --force-yes install python3 python3-virtualenv python3-dev git screen subversion cmake=3.13.4-1 cmake-data=3.13.4-1 avahi-daemon libavahi-compat-libdnssd1 libffi-dev libssl-dev libatlas3-base
 
 echo " - Reinstall iputils-ping"
 apt-get install --reinstall iputils-ping


### PR DESCRIPTION
I believe this is why the builds began failing around March 12th.  It appears the version of Cmake changed from 3.13.4-1 to 3.16.3-3~bpo10+1.

I found this fix while examining why v1pi was failing to build.
Apparently current cmake (3.16) fails with the GLOB operation and it sounds like it's related to this issue
https://gitlab.kitware.com/cmake/cmake/-/issues/20568
According to that thread, this is a consequence of an update within 3.15, and (probably) fixed sometime before 3.19.