### PR TITLE
♻️ Install OctoPrint from PyPI

### DIFF
--- a/src/modules/octopi/config
+++ b/src/modules/octopi/config
@@ -2,8 +2,7 @@
 # All our config settings must start with OCTOPI_
 
 # OctoPrint archive
-[ -n "$OCTOPI_OCTOPRINT_ARCHIVE" ] || OCTOPI_OCTOPRINT_ARCHIVE=$(wget -q -O - https://api.github.com/repos/foosel/OctoPrint/releases/latest | grep "zipball_url" | cut -d : -f 2,3 | tr -d \" | tr -d ,)
-[ -n "$OCTOPI_OCTOPRINT_REPO_SHIP" ] || OCTOPI_OCTOPRINT_REPO_SHIP=https://github.com/foosel/OctoPrint.git
+[ -n "$OCTOPI_OCTOPRINT_PACKAGE" ] || OCTOPI_OCTOPRINT_PACKAGE="OctoPrint"
 [ -n "$OCTOPI_INCLUDE_OCTOPRINT" ] || OCTOPI_INCLUDE_OCTOPRINT=yes
 
 # CuraEngine archive & version

--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -53,7 +53,7 @@ pushd /home/"${BASE_USER}"
   if [ "$OCTOPI_INCLUDE_OCTOPRINT" == "yes" ]
   then
     echo "--- Installing OctoPrint"
-    PIP_DEFAULT_TIMEOUT=60 sudo -u "${BASE_USER}" /home/"${BASE_USER}"/oprint/bin/pip install $OCTOPI_OCTOPRINT_ARCHIVE
+    PIP_DEFAULT_TIMEOUT=60 sudo -u "${BASE_USER}" /home/"${BASE_USER}"/oprint/bin/pip install $OCTOPI_OCTOPRINT_PACKAGE
   fi
 
   #mjpg-streamer


### PR DESCRIPTION
Instead of fetching the latest release on GitHub with a GitHub API call and installing the zip from that, let's simply install right from PyPI. And if a specific version is desired it can still be configured ("OctoPrint==1.6.1").