### PR TITLE
Update webcamd.service

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/systemd/system/webcamd.service
+++ b/src/modules/octopi/filesystem/root/etc/systemd/system/webcamd.service
@@ -8,7 +8,6 @@ StandardOutput=append:/var/log/webcamd.log
 StandardError=append:/var/log/webcamd.log
 ExecStart=/root/bin/webcamd
 Restart=always
-Type=forking
 RestartSec=1
 
 [Install]


### PR DESCRIPTION
correcting the systemd unit behavior to be in sync with the change operated on the /root/bin/webcamd script that does not fork anymore ( fixing #747 )