### PR TITLE
[Enhancement] Simplify multiple webcam handling and number of mjpg-streamer instances

### DIFF
--- a/src/modules/octopi/filesystem/boot/octopi.txt
+++ b/src/modules/octopi/filesystem/boot/octopi.txt
@@ -4,6 +4,17 @@
 ### MacOSX users: If you use Textedit to edit this file make sure to use 
 ### "plain text format" and "disable smart quotes" in "Textedit > Preferences"
 
+### Configure the max number of cameras Mjpg-streamer will handle
+#
+# Number of streams Mjpg-streamer will handle. Please be aware that the Rpi
+# may not be able to handle a lot of concurrent streams. Should the setting
+# appear more than once in all the configuration files, only the maximum 
+# value will be kept.
+#
+# Defaults to 2
+#
+#nb_max_camera=2
+
 ### Configure which camera to use
 #
 # Available options are:

--- a/src/modules/octopi/filesystem/home/root/bin/webcamd
+++ b/src/modules/octopi/filesystem/home/root/bin/webcamd
@@ -38,6 +38,8 @@ array_camera_http_options=()
 array_additional_brokenfps_usb_devices=()
 array_camera_device=()
 array_assigned_device=()
+input_string=""
+max_camera=2
 
 echo "--- Configuration: ----------------------------"
 for cfg_file in ${cfg_files[@]}; do
@@ -53,6 +55,11 @@ for cfg_file in ${cfg_files[@]}; do
       source "$cfg_file"
   fi
   usb_options="$camera_usb_options"
+
+  # if nb_max_camera is greater than actual setting, overwrite it
+  if [[ $nb_max_camera > $max_camera ]]; then
+    max_camera=$nb_max_camera
+  fi
 
   # if webcam device is explicitly given in /boot/octopi.txt, save the path of the device
   # to a variable and remove its parameter from usb_options
@@ -155,22 +162,22 @@ function runMjpgStreamer {
     fi
 
     pushd $MJPGSTREAMER_HOME > /dev/null 2>&1
-        echo Running ./mjpg_streamer -o "output_http.so -w $camera_http_webroot $camera_http_options" -i "$input"
-        LD_LIBRARY_PATH=. ./mjpg_streamer -o "output_http.so -w $camera_http_webroot $camera_http_options" -i "$input" &
+        echo Running ./mjpg_streamer -o "output_http.so -w $camera_http_webroot $camera_http_options" "$input"
+        LD_LIBRARY_PATH=. ./mjpg_streamer -o "output_http.so -w $camera_http_webroot $camera_http_options" "$input" &
         sleep 1 &
         sleep_pid=$!
         wait ${sleep_pid}
     popd > /dev/null 2>&1
 }
 
-# starts up the RasPiCam
-function startRaspi {
-    logger -s "Starting Raspberry Pi camera"
-    runMjpgStreamer "$MJPGSTREAMER_INPUT_RASPICAM $camera_raspi_options"
+# Adds the RasPiCam stream to Mjpg streamer input streams
+function addRaspiInput {
+    logger -s "Adding Raspberry Pi camera stream to input streams"
+    input_string+="-i '$MJPGSTREAMER_INPUT_RASPICAM $camera_raspi_options' "
 }
 
-# starts up the USB webcam
-function startUsb {
+# Adds an USB webcam stream to Mjpg streamer input streams
+function addUsbInput {
     options="$usb_options"
     device="video0"
 
@@ -208,7 +215,7 @@ function startUsb {
     fi
 
     logger -s "Starting USB webcam"
-    runMjpgStreamer "$MJPGSTREAMER_INPUT_USB $options"
+    input_string+="-i '$MJPGSTREAMER_INPUT_USB $options' "
 }
 
 # make sure our cleanup function gets called when we receive SIGINT, SIGTERM
@@ -261,8 +268,21 @@ while true; do
           elif containsString "$usb_device_path" "${video_devices[@]}"; then
             array_camera_device[${i}]="$usb_device_path"
             # explicitly set usb device was found in video_devices array, start usb with the found device
-            echo "config file='$camera_config':USB device was set in options and found in devices, starting MJPG-streamer with the configured USB video device: $usb_device_path"
-            startUsb "$usb_device_path"
+            # Check whether we allow an additional input stream
+            if [[ $max_camera > 0 ]]; then
+              # Check if the video device has the Video Capture capability or not before adding it to input streams to prevent errors (needs v4l2-ctl command provided by v4l-utils package)
+              echo "will run v4l2-ctl --list-formats -d \"$usb_device_path\"|wc -l"
+              if [[ $(v4l2-ctl --list-formats -d "$usb_device_path"|wc -l) > 3 ]]; then
+                echo "config file='$camera_config':USB device was set in options and found in devices, adding input stream to MJPG-streamer with the configured USB video device: $usb_device_path"
+                addUsbInput "$usb_device_path"
+                max_camera=$max_camera-1
+              else
+                echo "Cannot add $usb_device_path to input streams as it does not offer video capture capability"
+              fi
+            # Otherwise, notify the stream can't be added to input streams
+            else
+              echo "Cannot add $usb_device_path to input streams, maximum stream number reached. Please consider increasing nb_max_camera setting in '$camera_config' or remove cameras"
+            fi
             continue
           fi
 
@@ -273,10 +293,22 @@ while true; do
                 : #already in use
               else
                 array_camera_device[${i}]="$video_device"
-                # device is not set explicitly in options, start usb with first found usb camera as the device
-                echo "config file='$camera_config':USB device was not set in options, starting MJPG-streamer with the first found video device: ${video_device}"
-                startUsb "${video_device}"
-                break
+                # device is not set explicitly in options, add device to input streams if there are any left
+                # Check whether we allow an additional input stream
+                if [[ $max_camera > 0 ]]; then
+                  # Check if the video device has the Video Capture capability or not before adding it to input streams to prevent errors (needs v4l2-ctl command provided by v4l-utils package)
+                  if [[ $(v4l2-ctl --list-formats -d "${video_device}"|wc -l) > 3 ]]; then
+                    echo "config file='$camera_config':USB device was not set in options, adding input stream to MJPG-streamer with found video device: ${video_device}"
+                    addUsbInput "${video_device}"
+                    max_camera=$max_camera-1
+                  else
+                    echo "Cannot add ${video_device} to input streams as it does not offer video capture capability"
+                  fi
+                # Otherwise, notify the stream can't be added to input streams
+                else
+                  echo "Cannot add $usb_device_path to input streams, maximum stream number reached. Please consider increasing settings or remove cameras"
+                  break
+                fi
               fi
             fi
           done
@@ -295,7 +327,14 @@ while true; do
           elif containsString "$video_device" "${video_devices[@]}"; then
             array_camera_device[${i}]="$video_device"
             echo "config file='$camera_config':Starting MJPG-streamer with video device: ${video_device}"
-            startRaspi
+            # Check whether we allow an additional input stream
+            if [[ $max_camera > 0 ]]; then
+                addRaspiInput
+                max_camera=$max_camera-1
+            # Otherwise, notify the stream can't be added to input streams
+            else
+              echo "Cannot add $video_device to input streams, maximum stream number reached. Please consider increasing settings or remove cameras"
+            fi
             sleep 30 &
             sleep_pid=$!
             wait ${sleep_pid}
@@ -304,6 +343,10 @@ while true; do
       fi
     done
   done
+  # Start Mjpg-streamer
+  if [[ -n "$input_string" ]]; then
+      runMjpgStreamer "$input_string"
+  fi;
 
   array_assigned_device=( ${array_camera_device[*]} )
   if [[ ${#array_camera[@]} -eq ${#array_assigned_device[@]} ]]; then

--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -284,6 +284,7 @@ systemctl_if_exists enable streamer_select.service
 
 if [ "$OCTOPI_INCLUDE_MJPGSTREAMER" == "yes" ]
 then
+  apt-get -y install v4l-utils
   systemctl_if_exists enable webcamd.service
 else
   rm /etc/logrotate.d/webcamd


### PR DESCRIPTION
[mjpg-streamer](https://github.com/jacksonliam/mjpg-streamer) is able to handle multiple input and/or output streams (by specifying multiple `-i` or `-o` flags). In order to reduce the overhead created by spawning multiple instances of `mjpg-streamer`, as well as simplifying the reverse proxy configuration (either HAProxy or other reverse proxy software), I've modified the `webcamd` script to be able to allow for multiple input streams.

If multiple input streams are available, a setting in `octopi.txt` or any supplementary `*.txt` config file is introduced, which will cap the maximum input streams to 2 so that the pi doesn't suffer too much strain. The default value is now 2, but that can be reduced or increased, I just thought it would be a sensible default.

Also, this modification removes the limitation of offering either USB or Raspicam support, both should be available with this modification. The script is now able to add multiple stream input automatically, not limited to the first `/dev/video` device encountered. It also relies on the `v4l2-ctl` command (available through the `v4l-utils` package) to determine whether a `/dev/video*` device offers Video Capture capabilities and so can be used as an input stream for `mjpg-streamer`.

Unfortunately, I don't own an Rpi device nor a Raspicam, so I'm not able to test those functionalities on real hardware, though the script runs the appropriate commands in a similar Linux environment.

I welcome any feedback you might have regarding this PR.

Best regards