### PR TITLE
[Improvement] When using HLS camera streamer, generate frame snapshot only once a second

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/systemd/system/ffmpeg_hls.service
+++ b/src/modules/octopi/filesystem/root/etc/systemd/system/ffmpeg_hls.service
@@ -25,7 +25,7 @@ ExecStart=/usr/bin/sudo -u webcam \
     -pix_fmt yuv420p \
     \
     -c:v mjpeg -q:v 0 \
-    -f image2 -update 1 -atomic_writing 1 \
+    -f image2 -r 1 -update 1 -atomic_writing 1 \
     /run/webcam/jpeg/frame.jpg \
     \
     -c:v h264_omx -profile:v high \


### PR DESCRIPTION
When using the experimental HLS camera streamer, an image snapshot is being generated for each frame, encoded to JPG and atomically written to the filesystem.

This creates a huge CPU cycle and IO burden at the configured 30 fps -  when running on a Raspberry 3B, the current setup consumes over ~70% CPU.

With this PR, ffmpeg is configured to only generate a snapshot once a second, reducing the resulting CPU load to ~20% on a RP 3B.