### PR TITLE
Fix building against bullseye

### DIFF
--- a/src/modules/octopi/config
+++ b/src/modules/octopi/config
@@ -20,9 +20,6 @@
 # HAProxy
 [ -n "$OCTOPI_INCLUDE_HAPROXY" ] || OCTOPI_INCLUDE_HAPROXY=yes
 
-# WiringPi
-[ -n "$OCTOPI_INCLUDE_WIRINGPI" ] || OCTOPI_INCLUDE_WIRINGPI=yes
-
 # yq
 [ -n "$OCTOPI_YQ_DOWNLOAD" ] || OCTOPI_YQ_DOWNLOAD=$(wget -q -O - https://api.github.com/repos/mikefarah/yq/releases/latest | grep "browser_download_url" | grep "yq_linux_arm" | cut -d : -f 2,3 | tr -d \" | tr -d ,)
 

--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -149,12 +149,6 @@ EOT
     rm /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/certs/ssl-cert-snakeoil.pem
   fi
 
-  if [ "$OCTOPI_INCLUDE_WIRINGPI" == "yes" ]
-  then
-    echo "--- Installing WiringPi"
-    apt-get -y install wiringpi
-  fi
-
   # fetch current yq build and install to /usr/local/bin
   wget -O yq $OCTOPI_YQ_DOWNLOAD && chmod +x yq && mv yq /usr/local/bin
   

--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -34,12 +34,7 @@ echo "removing:" $remove_extra
 apt-get remove -y --purge  $remove_extra
 apt-get autoremove -y
 
-if [ "${BASE_DISTRO}" == "ubuntu" ]; then
-    apt-get -y --force-yes install python3 python3-virtualenv python3-dev git screen subversion cmake cmake-data avahi-daemon libavahi-compat-libdnssd1 libffi-dev libssl-dev libatlas3-base unzip
-else
-    apt-get -y --force-yes install python3 python3-virtualenv python3-dev git screen subversion cmake=3.13.4-1 cmake-data=3.13.4-1 avahi-daemon libavahi-compat-libdnssd1 libffi-dev libssl-dev libatlas3-base
-fi
-
+apt-get -y --force-yes install python3 python3-virtualenv python3-dev git screen subversion cmake cmake-data avahi-daemon libavahi-compat-libdnssd1 libffi-dev libssl-dev libatlas3-base unzip
 
 echo " - Reinstall iputils-ping"
 apt-get install --reinstall iputils-ping


### PR DESCRIPTION
This removes the version pin on cmake and removes wiringpi, which is no longer maintained and now not even available in the repository anymore.

Note that this currently will in all likelihood not build because there's an unrelated issue with a Python dependency `regex` currently ongoing that the OctoPrint build is depending on (see mrabarnett/mrab-regex#443). I'm hopeful that that will be fixed soon though (the dependency was updated today and the release lacks some mandatory files). Marking this as draft for now until I can confirm.

I was temporarily able to work around the aforementioned issue by injecting

      sudo -u "${BASE_USER}" /home/"${BASE_USER}"/oprint/bin/pip install regex==2021.11.2

into the chroot script, and can confirm that the build runs through then after the changes in this PR.