### PR TITLE
Set systemd Type to simple instead of forking

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/systemd/system/webcamd.service
+++ b/src/modules/octopi/filesystem/root/etc/systemd/system/webcamd.service
@@ -8,7 +8,7 @@ StandardOutput=append:/var/log/webcamd.log
 StandardError=append:/var/log/webcamd.log
 ExecStart=/root/bin/webcamd
 Restart=always
-Type=forking
+Type=simple
 RestartSec=1
 
 [Install]

--- a/src/variants/ubuntu_arm64/filesystem/root/etc/systemd/system/webcamd.service
+++ b/src/variants/ubuntu_arm64/filesystem/root/etc/systemd/system/webcamd.service
@@ -8,7 +8,7 @@ StandardOutput=append:/var/log/webcamd.log
 StandardError=append:/var/log/webcamd.log
 ExecStart=/root/bin/webcamd
 Restart=always
-Type=forking
+Type=simple
 RestartSec=1
 
 [Install]


### PR DESCRIPTION
Hello :) 

I've seen several issues related to webcamd restarting very frequently and ran in the same issue:

```
The unit webcamd.service completed and consumed the indicated resources.
Feb 08 20:34:56 octopi systemd[1]: webcamd.service: Scheduled restart job, restart counter is at 5.
```

[This mention](https://community.octoprint.org/t/webcam-freezing-after-a-few-seconds/31921/5) in the community fixed it for me and as I didn't see it in this branch yet, a PR to change this behaviour. 

Hope you are willing to merge this. 

Thanks a lot for maintaining this repository :) Keep up the good work!