### PR TITLE
Install vcgencmd and fix user permission on Ubuntu

### DIFF
--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -158,6 +158,12 @@ popd
 usermod -a -G tty "${BASE_USER}"
 usermod -a -G dialout "${BASE_USER}"
 
+# If building against Ubuntu, make sure vcgencmd is available and pi has the rights to use it
+if [ "${BASE_DISTRO}" == "ubuntu" ]; then
+  apt-get -y --force-yes install libraspberrypi-bin
+  usermod -a -G video "${BASE_USER}"
+fi
+
 # store octopi commit used to build this image
 echo "$OCTOPI_COMMIT" > /etc/octopi_commit
 


### PR DESCRIPTION
The 64bit images are currently lacking vcgencmd, meaning that the
PiSupport plugin can't check for undervoltage and overheat
situations and will complain about this in the latest version
as well, see feedback in #770.

This should fix it by installing the package containing vcgencmd
and making sure the base user is added to the video group as
well.

**I was not able to test this in a build since I could not find
documentation on which base image exactly to use and how
to precisely run the 64bit build, but based on user feedback
it should hopefully work. Still, please test in a build before
merging.**