### PR TITLE
Fix HAProxy warning on wrong timeout abrreviation

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/haproxy/haproxy.2.x.cfg
+++ b/src/modules/octopi/filesystem/root/etc/haproxy/haproxy.2.x.cfg
@@ -17,8 +17,8 @@ defaults
         option forwardfor
         maxconn 2000
         timeout connect 5s
-        timeout client  15min
-        timeout server  15min
+        timeout client  15m
+        timeout server  15m
 
 frontend public
         bind :::80 v4v6


### PR DESCRIPTION
I was fixing my OctoPi install after doing a dist-upgrade (buster to bullseye) and breaking haproxy in the process... I fixed that issue by replacing my haproxy cfg with the one that's located on master here, and haproxy restarted, but threw a warning.

```
Mar 28 19:26:51 octopi haproxy[747]: [WARNING] 086/192651 (747) : unexpected character 'i' after the timer value '15min', only (us=microseconds,ms=milliseconds,s=seconds,m=minutes,h=hours,d=days) are supported. This w…or in next versions.
Mar 28 19:26:51 octopi haproxy[747]: [WARNING] 086/192651 (747) : unexpected character 'i' after the timer value '15min', only (us=microseconds,ms=milliseconds,s=seconds,m=minutes,h=hours,d=days) are supported. This w…or in next versions.
```

This PR addresses that.

Information on the system:
```
pi@octopi:~ $ haproxy -v
HA-Proxy version 2.2.9-2+rpi1+deb11u3 2022/03/17 - https://haproxy.org/
Status: long-term supported branch - will stop receiving fixes around Q2 2025.
Known bugs: http://www.haproxy.org/bugs/bugs-2.2.9.html
Running on: Linux 5.10.103-v7+ #1529 SMP Tue Mar 8 12:21:37 GMT 2022 armv7l
```
Running OctoPi 0.17.0 (with a manual upgrade to Debian Bullseye)