### PR TITLE
Fix webcamd.service type

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/systemd/system/webcamd.service
+++ b/src/modules/octopi/filesystem/root/etc/systemd/system/webcamd.service
@@ -8,7 +8,7 @@ StandardOutput=append:/var/log/webcamd.log
 StandardError=append:/var/log/webcamd.log
 ExecStart=/root/bin/webcamd
 Restart=always
-Type=forking
+Type=simple
 RestartSec=1
 
 [Install]


### PR DESCRIPTION
`forking` is wrong, needs to be `simple`.

Apparently not an issue on Buster, but fails
spectacularly on Bullseye.

Tested against 1.0.0 RC image. Without patch: Camera restarts every minute. With Patch: Doesn't restart.

Thanks @PowerWiesel

Closes #747

