### PR TITLE
Ensure webcamd service type is simple, not forking on rpios 64

### DIFF
--- a/src/variants/rpios_arm64/filesystem/root/etc/systemd/system/webcamd.service
+++ b/src/variants/rpios_arm64/filesystem/root/etc/systemd/system/webcamd.service
@@ -8,7 +8,7 @@ StandardOutput=append:/var/log/webcamd.log
 StandardError=append:/var/log/webcamd.log
 ExecStart=/root/bin/webcamd
 Restart=always
-Type=forking
+Type=simple
 RestartSec=1
 
 [Install]


### PR DESCRIPTION
See #788 for details. It was set in the 32 bit & 64 bit ubuntu variant, but not this one.
