### PR TITLE
Fix vcgencmd get_camera output matching with libcamera

### DIFF
--- a/src/modules/octopi/filesystem/home/root/bin/webcamd
+++ b/src/modules/octopi/filesystem/home/root/bin/webcamd
@@ -227,7 +227,9 @@ while true; do
   video_devices=($(find /dev -regextype sed -regex '\/dev/video[0-9]\+' | sort 2> /dev/null))
 
   # add list of raspi camera into an array
-  if [ "`vcgencmd get_camera`" = "supported=1 detected=1" ]; then
+  vcgencmd_regex="supported=1 detected=1.*"
+  # Example output matching: supported=1 detected=1, libcamera interfaces=0
+  if [[ "`vcgencmd get_camera`" =~ $vcgencmd_regex ]]; then
     video_devices+=( "raspi" )
   fi
 


### PR DESCRIPTION
On the newer images (incl. 1.0.0RC2, and if you run `sudo apt upgrade` on an older one - even buster) vcgencmd has been updated with different output:

```
supported=1 detected=1, libcamera interfaces=0
```

This comparison to the exact string then broke. Users with `camera="raspi"` meant that their cameras were not detected, such as this post on the forums https://community.octoprint.org/t/cannot-get-the-picam-to-work/45922/2?u=charlie_powell. Luckily it can be used in 'usb' mode as well with the v4l2 driver.

I have not verified that this change allows webcamd to work completely with a Raspberry Pi camera as I don't have one, but the regex matching has been tested. 