### PR TITLE
Add user-fix script to allow changing usernames

### DIFF
--- a/src/modules/octopi/filesystem/home/root/bin/user-fix
+++ b/src/modules/octopi/filesystem/home/root/bin/user-fix
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Written by Gina Häußge originally at https://github.com/OctoPrint/OctoPi-UpToDate/blob/e70ccdaf0cd4ef4adfaa3f9b6b288fb6bfda116a/scripts/files/user-fix
+
+set -e
+
+USERID=1000
+FIRSTUSER=`getent passwd $USERID | cut -d: -f1`
+FIRSTUSERHOME=`getent passwd $USERID | cut -d: -f6`
+
+CURRENT=`grep User= /etc/systemd/system/octoprint.service | cut -d= -f2`
+
+if [ "$CURRENT" = "pi" -a "$FIRSTUSER" != "pi" ]; then
+    # if we get here it means that the first user was renamed but we haven't yet
+    # updated all of OctoPi's files that depend on that name, so let's do that now
+
+    # first we need to figure out if we can use the new user name in systemd files
+    # directly or if we need to use the UID - we do that by checking if the
+    # escaped name differes from the plain name, if so something is non ASCII
+    # and the UID is the safer bet
+    FIRSTUSERESC=`systemd-escape "$FIRSTUSER"`
+    if [ "$FIRSTUSER" != "$FIRSTUSERESC" ]; then
+        SERVICEUSER=$USERID
+    else
+        SERVICEUSER=$FIRSTUSER
+    fi
+
+    # fix OctoPrint service file
+    echo "Fixing service file"
+    sed -i "s!User=pi!User=$SERVICEUSER!g" /etc/systemd/system/octoprint.service
+    sed -i "s!ExecStart=/home/pi/!ExecStart=$FIRSTUSERHOME/!g" /etc/systemd/system/octoprint.service
+    systemctl daemon-reload
+
+    # fix sudoers files
+    echo "Fixing sudoers"
+    sed -i "s!^pi!$FIRSTUSER!g" /etc/sudoers.d/octoprint-service
+    sed -i "s!^pi!$FIRSTUSER!g" /etc/sudoers.d/octoprint-shutdown
+
+    # fix scripts
+    echo "Fixing scripts"
+    sed -i "s!/home/pi/!$FIRSTUSERHOME/!g" $FIRSTUSERHOME/scripts/add-octoprint-checkout
+    sed -i "s!/home/pi/!$FIRSTUSERHOME/!g" $FIRSTUSERHOME/scripts/welcome
+    sed -i "s!/home/pi/!$FIRSTUSERHOME/!g" $FIRSTUSERHOME/.bashrc
+    sed -i "s!/home/pi/!$FIRSTUSERHOME/!g" /root/bin/webcamd
+
+    # fix virtualenv
+    echo "Fixing paths in virtual environment"
+    cd $FIRSTUSERHOME/oprint
+    sudo -u $FIRSTUSER $FIRSTUSERHOME/.local/bin/virtualenv-tools --update-path $FIRSTUSERHOME/oprint
+
+    # finally, reboot for all of this to actually take affect
+    echo "Adjusted scripts to new user, restarting services..."
+    systemctl reboot
+fi

--- a/src/modules/octopi/filesystem/root/etc/systemd/system/user-fix.service
+++ b/src/modules/octopi/filesystem/root/etc/systemd/system/user-fix.service
@@ -1,0 +1,18 @@
+# Written by Gina Häußge originally at https://github.com/OctoPrint/OctoPi-UpToDate/blob/e70ccdaf0cd4ef4adfaa3f9b6b288fb6bfda116a/scripts/files/user-fix.service
+[Unit]
+Description=Ensure that user name changes are applied as needed
+
+DefaultDependencies=no
+
+Before=network-pre.target
+Wants=network-pre.target
+
+After=local-fs.target
+Wants=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/root/bin/user-fix
+
+[Install]
+WantedBy=multi-user.target

--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -329,6 +329,15 @@ systemctl_if_exists enable networkcheck.timer
 echo "--- Installing avrdude"
 apt-get -y install avrdude
 
+### User-fixing
+# Users can change their username easily via the Raspberry Pi imager, which breaks some of OctoPi's scripts
+# we need to install virtualenv-tools3, so let's get pip and that
+apt install -y python3-pip
+sudo -u pi pip3 install --user virtualenv-tools3
+
+systemctl_if_exists enable user-fix.service
+
+
 #cleanup
 apt-get clean
 apt-get autoremove -y


### PR DESCRIPTION
This moves the script for allowing username changes from the emergency patch in OctoPi-UpToDate, to OctoPi itself. Gina mentioned that it needed doing, so I prepared the PR.

This allows for someone to change the username in the Raspberry Pi imager before flashing the image. It does make the 'first boot' take longer as a restart is required for the changes to take affect, should they be needed.

I have tested it on a 32 bit build, although it was with FFMPEG HLS disabled due to the build time being long with that. I don't think that should impact usability of the image.

This concept has been working for a little while with the current 0.18 image patched, so hopefully this continues to work well.