### PR TITLE
Update Octoprint Systemd Service to fall back to System CA bundle

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/systemd/system/octoprint.service
+++ b/src/modules/octopi/filesystem/root/etc/systemd/system/octoprint.service
@@ -6,6 +6,7 @@ Wants=network.online.target
 [Service]
 Environment="HOST=127.0.0.1"
 Environment="PORT=5000"
+Environment="REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
 Type=simple
 User=pi
 ExecStart=/home/pi/oprint/bin/octoprint serve --host=${HOST} --port=${PORT}


### PR DESCRIPTION
Octoprint, because it does not specify a CA bundle anywhere, falls back to the default Python CA bundle.  This prevents a user from adding a trusted CA, and being able to use that for connections from Octoprint.

This change lets Octoprint fall back to use the Debian/Raspbian default CA bundle - so that users can update the CA certificates for the OS (and not have to find other options to figure out how to separately change Python's CA cert bundle.