### PR TITLE
Adding missing if closing statement

### DIFF
--- a/src/modules/octopi/filesystem/root/usr/local/bin/networkcheck
+++ b/src/modules/octopi/filesystem/root/usr/local/bin/networkcheck
@@ -2,7 +2,8 @@
 CONFIG_FILE=/boot/firmware/octopi.txt
 # Fallback for older images
 if [ ! -f "${CONFIG_FILE}" ] && [ -f "/boot/octopi.txt" ]; then
-CONFIG_FILE=/boot/octopi.txt
+    CONFIG_FILE=/boot/octopi.txt
+fi
 
 source "${CONFIG_FILE}"
 


### PR DESCRIPTION
Networkcheck service is continually failing for an "unexpected end of file" error, adding in a missing if closing to resolve error