### PR TITLE
switch to modern OS dependencies for latest numpy versions

### DIFF
--- a/src/modules/octopi/start_chroot_script
+++ b/src/modules/octopi/start_chroot_script
@@ -35,7 +35,7 @@ echo "removing:" $remove_extra
 apt-get remove -y --purge  $remove_extra
 apt-get autoremove -y
 
-apt-get -y --allow-change-held-packages install python3 python3-virtualenv python3-dev git screen subversion cmake cmake-data avahi-daemon libavahi-compat-libdnssd1 libffi-dev libssl-dev libatlas3-base unzip
+apt-get -y --allow-change-held-packages install python3 python3-virtualenv python3-dev git screen subversion cmake cmake-data avahi-daemon libavahi-compat-libdnssd1 libffi-dev libssl-dev unzip libopenblas0-pthread libgfortran5
 
 echo " - Reinstall iputils-ping"
 apt-get -y --force-yes install --reinstall iputils-ping


### PR DESCRIPTION
similar to the previous addition of system level dependencies for numpy discussed in https://github.com/guysoft/OctoPi/issues/676, those dependencies have changed with numpy version 2+. As seen on piwheels: https://www.piwheels.org/project/numpy/