### PR TITLE
Fix config_dir for webcamd

### DIFF
--- a/src/modules/octopi/filesystem/home/root/bin/webcamd
+++ b/src/modules/octopi/filesystem/home/root/bin/webcamd
@@ -16,14 +16,14 @@ MJPGSTREAMER_INPUT_USB="input_uvc.so"
 MJPGSTREAMER_INPUT_RASPICAM="input_raspicam.so"
 
 CONFIG_FILE=/boot/firmware/octopi.txt
+config_dir="/boot/firmware/octopi.conf.d"
 # Fallback for older images
 if [ ! -f "${CONFIG_FILE}" ] && [ -f "/boot/octopi.txt" ]; then
 CONFIG_FILE=/boot/octopi.txt
+config_dir="/boot/octopi.conf.d"
 fi
 
 brokenfps_usb_devices=("046d:082b" "1908:2310" "0458:708c" "0458:6006" "1e4e:0102" "0471:0311" "038f:6001" "046d:0804" "046d:0994" "0ac8:3450")
-
-config_dir="${CONFIG_FILE}/octopi.conf.d"
 
 echo "Starting up webcamDaemon..."
 echo ""


### PR DESCRIPTION
370549c added support for /boot/firmware config location. But that change config_dir to use CONFIG_FILE in path calculation, resulting to an invalid path.

Set the config_dir to the correct location, while also taking in account the fallback for older images.

This was inspired by the comment from [1].

[1] - https://community.octoprint.org/t/setting-up-multiple-webcams-in-octopi-the-right-way/32669/197