### PR TITLE
fix issues related to GPIO and bookworm, #857

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/systemd/system/octoprint.service
+++ b/src/modules/octopi/filesystem/root/etc/systemd/system/octoprint.service
@@ -7,6 +7,7 @@ Wants=network.online.target
 Environment="HOST=127.0.0.1"
 Environment="PORT=5000"
 Environment="REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
+Environment="LG_WD=/tmp"
 Type=simple
 User=1000
 ExecStart=/opt/octopi/oprint/bin/octoprint serve --host=${HOST} --port=${PORT}


### PR DESCRIPTION
update octoprint.service adding Environment="LG_WD=/tmp" to handle differences with GPIO access in bookworm, resolves #857 