### PR TITLE
Replace network.online.target with network-online.target

### DIFF
--- a/src/modules/octopi/filesystem/root/etc/systemd/system/octoprint.service
+++ b/src/modules/octopi/filesystem/root/etc/systemd/system/octoprint.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=The snappy web interface for your 3D printer
-After=network.online.target
-Wants=network.online.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Environment="HOST=127.0.0.1"


### PR DESCRIPTION
Probably a typo, `network.online.target` is not a valid target (see [the documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/systemd-network-targets-and-services_configuring-and-managing-networking#differences-between-the-network-and-network-online-systemd-target_systemd-network-targets-and-services)). This seems to also fix https://github.com/OctoPrint/OctoPrint/issues/5176