### PR TITLE
Switch e2e screenshot browser to firefox-esr

### DIFF
--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -6,11 +6,11 @@ FROM ptrsr/pi-ci:latest
 ENV LIBGUESTFS_BACKEND=direct
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    sshpass openssh-client curl socat imagemagick wget gnupg \
-    dbus dbus-x11 fonts-liberation tesseract-ocr \
-    && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
-    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
-    && apt-get update && apt-get install -y --no-install-recommends google-chrome-stable \
+    sshpass openssh-client curl socat imagemagick wget gnupg ca-certificates \
+    dbus dbus-x11 fonts-liberation fonts-noto-cjk tesseract-ocr \
+    software-properties-common \
+    && add-apt-repository -y ppa:mozillateam/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends firefox-esr \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=custompios /CustomPiOS/distro_testing/scripts/ /test/scripts/


### PR DESCRIPTION
## Summary
- Fixes the failing `devel` e2e-test (run [30759697193](https://github.com/guysoft/OctoPi/actions/runs/30759697193/job/91545664616)): Chrome 147+ no longer produces `--headless --screenshot` images in the e2e container, so the screenshot retry loop consumed the 30-min job timeout.
- Replaces `google-chrome-stable` with `firefox-esr` (Mozilla Team PPA; base image is Ubuntu 24.04 Noble). Firefox's `--screenshot` CLI is stable and ESR pins a major version for ~12 months.
- Pairs with the merged CustomPiOS helper update ([CustomPiOS#275](https://github.com/guysoft/CustomPiOS/pull/275), now in `ghcr.io/guysoft/custompios:devel`): `browser-helpers.sh` prefers `firefox-esr`/`firefox` and falls back to Chrome. Validated locally: `firefox-esr 140.13.0esr` installs and `--headless --no-remote --screenshot` emits a real PNG.

## Test plan
- [ ] `e2e-test` job passes: OctoPrint wizard (HTTP 200 + CONFIG_WIZARD) verified.
- [ ] Screenshot artifact produced via Firefox (no 30-min timeout).
- [ ] No regression vs the pre-Chrome-147 green run.